### PR TITLE
templates: rename pitch placeholder to blurb

### DIFF
--- a/templates/cms_homepage.html
+++ b/templates/cms_homepage.html
@@ -1,4 +1,4 @@
-{% extends "cms_default.html" %}
+/{% extends "cms_default.html" %}
 {% load cms_tags %}
 
 {% block pagebanner-class %}homepage-splash-banner{% endblock %}
@@ -6,7 +6,7 @@
 <div class='row'>
   <div id='splash-banner-pitch'>
     <h2>{% page_attribute "page_title" %}</h2>
-    {% placeholder "pitch" %}
+    {% placeholder "blurb" %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Placeholders called 'blurb' is the convention we use everywhere else so we should use that for the home page as well.
