### PR TITLE
organisation: attach menu to the network groups' cms app

### DIFF
--- a/foundation/organisation/cms_app.py
+++ b/foundation/organisation/cms_app.py
@@ -1,7 +1,7 @@
 from cms.app_base import CMSApp
 from cms.apphook_pool import apphook_pool
 from django.utils.translation import ugettext_lazy as _
-from .menu import ProjectMenu
+from .menu import ProjectMenu, NetworkGroupMenu
 
 
 class UnitsAppHook(CMSApp):
@@ -43,5 +43,6 @@ apphook_pool.register(WorkingGroupsAppHook)
 class NetworkGroupsAppHook(CMSApp):
     name = _("Network Groups")
     urls = ["foundation.organisation.urls.networkgroups"]
+    menus = [NetworkGroupMenu]
 
 apphook_pool.register(NetworkGroupsAppHook)

--- a/foundation/organisation/menu.py
+++ b/foundation/organisation/menu.py
@@ -2,7 +2,7 @@ from menus.base import NavigationNode
 from menus.menu_pool import menu_pool
 from django.utils.translation import ugettext_lazy as _
 from cms.menu_bases import CMSAttachMenu
-from .models import Project
+from .models import Project, NetworkGroup
 
 
 class ProjectMenu(CMSAttachMenu):
@@ -21,3 +21,31 @@ class ProjectMenu(CMSAttachMenu):
         return nodes
 
 menu_pool.register_menu(ProjectMenu)
+
+
+class NetworkGroupMenu(CMSAttachMenu):
+
+    name = _('Network Group')
+
+    def get_nodes(self, request):
+        nodes = []
+        for group in NetworkGroup.objects.countries():
+            node = NavigationNode(
+                group.get_country_display(),
+                group.get_absolute_url(),
+                group.pk,
+            )
+            nodes.append(node)
+
+            for regiongroup in NetworkGroup.objects\
+                    .regions(country=group.country_slug):
+                node = NavigationNode(
+                    regiongroup.region,
+                    regiongroup.get_absolute_url(),
+                    regiongroup.pk,
+                    group.pk,
+                    )
+                nodes.append(node)
+        return nodes
+
+menu_pool.register_menu(NetworkGroupMenu)


### PR DESCRIPTION
This makes breadcrumbs work (and it is organised so that regional
groups are sub pages of country groups). Fixes partly #118 
