### PR TITLE
press: adjust press release user interface

### DIFF
--- a/foundation/press/templates/press/pressrelease_list.html
+++ b/foundation/press/templates/press/pressrelease_list.html
@@ -20,6 +20,7 @@
           <h3>{% include "press/pressrelease_title.html" %}</h3>
           {% include "press/pressrelease_date.html" %}
         </div>
+        {% if not forloop.last%}<hr>{% endif %}
         {% endfor %}
       {% else %}
         {% for pressrelease in object_list %}
@@ -27,6 +28,7 @@
           <h3>{% include "press/pressrelease_title.html" %}</h3>
           {% include "press/pressrelease_date.html" %}
         </div>
+        {% if not forloop.last%}<hr>{% endif %}
         {% empty %}
         <p>{% trans 'No press releases found.' %}</p>
         {% endfor %}

--- a/static/less/main.less
+++ b/static/less/main.less
@@ -484,6 +484,11 @@ img.network-group-flag {
   p {
     margin-top: 8px;
   }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
 }
 
 .press-mention {


### PR DESCRIPTION
CSS changes to set maximum width of images to 100% in press releases
and put a horizontal rule between press release headers in main
column.

Fixes #110 
