### PR TITLE
Transform project list into a project gallery

### DIFF
--- a/foundation/organisation/migrations/0028_auto__add_field_projecttype_slug__add_field_project_featured.py
+++ b/foundation/organisation/migrations/0028_auto__add_field_projecttype_slug__add_field_project_featured.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'ProjectType.slug'
+        db.add_column(u'organisation_projecttype', 'slug',
+                      self.gf('django.db.models.fields.SlugField')(default='', unique=False, max_length=100),
+                      keep_default=False)
+
+        # Adding field 'Project.featured'
+        db.add_column(u'organisation_project', 'featured',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding slug and setting it as unique
+        if not db.dry_run:
+            for projecttype in orm['organisation.ProjectType'].objects.all():
+                projecttype.slug = slugify(projecttype.name)
+                projecttype.save()
+        db.create_unique(u'organisation_projecttype', ['slug'])
+
+    def backwards(self, orm):
+        # Deleting field 'ProjectType.slug'
+        db.delete_column(u'organisation_projecttype', 'slug')
+
+        # Deleting field 'Project.featured'
+        db.delete_column(u'organisation_project', 'featured')
+
+
+    models = {
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        u'organisation.board': {
+            'Meta': {'object_name': 'Board'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Person']", 'through': u"orm['organisation.BoardMembership']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.boardmembership': {
+            'Meta': {'object_name': 'BoardMembership'},
+            'board': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Board']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Person']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.featuredproject': {
+            'Meta': {'object_name': 'FeaturedProject', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': u"orm['organisation.Project']"})
+        },
+        u'organisation.featuredtheme': {
+            'Meta': {'object_name': 'FeaturedTheme', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'theme': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': u"orm['organisation.Theme']"})
+        },
+        u'organisation.networkgroup': {
+            'Meta': {'ordering': "('country', 'region')", 'unique_together': "(('country', 'region'),)", 'object_name': 'NetworkGroup'},
+            'country': ('django_countries.fields.CountryField', [], {'max_length': '2'}),
+            'country_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'extra_information': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'facebook_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'group_type': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'homepage_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mailinglist_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Person']", 'through': u"orm['organisation.NetworkGroupMembership']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'position': ('geoposition.fields.GeopositionField', [], {'default': "'0,0'", 'max_length': '42', 'null': 'True', 'blank': 'True'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'region_slug': ('django.db.models.fields.SlugField', [], {'default': 'None', 'max_length': '50'}),
+            'twitter': ('django.db.models.fields.CharField', [], {'max_length': '18', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'working_groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.WorkingGroup']", 'symmetrical': 'False', 'blank': 'True'}),
+            'youtube': ('django.db.models.fields.CharField', [], {'max_length': '18', 'blank': 'True'})
+        },
+        u'organisation.networkgroupmembership': {
+            'Meta': {'ordering': "['-order', 'person__name']", 'object_name': 'NetworkGroupMembership'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'networkgroup': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.NetworkGroup']"}),
+            'order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Person']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.person': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Person'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'twitter': ('django.db.models.fields.CharField', [], {'max_length': '18', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        u'organisation.project': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Project'},
+            'banner': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'homepage_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mailinglist_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'picture': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'sourcecode_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'teaser': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'themes': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Theme']", 'symmetrical': 'False', 'blank': 'True'}),
+            'twitter': ('django.db.models.fields.CharField', [], {'max_length': '18', 'blank': 'True'}),
+            'types': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.ProjectType']", 'symmetrical': 'False', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.projectlist': {
+            'Meta': {'object_name': 'ProjectList', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'project_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.ProjectType']", 'null': 'True', 'blank': 'True'}),
+            'theme': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Theme']", 'null': 'True', 'blank': 'True'})
+        },
+        u'organisation.projecttype': {
+            'Meta': {'object_name': 'ProjectType'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.signupform': {
+            'Meta': {'object_name': 'SignupForm', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "'Get Connected to Open Knowledge'", 'max_length': '50'})
+        },
+        u'organisation.theme': {
+            'Meta': {'object_name': 'Theme'},
+            'blurb': ('django.db.models.fields.TextField', [], {}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'picture': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.unit': {
+            'Meta': {'ordering': "['-order', 'name']", 'object_name': 'Unit'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Person']", 'through': u"orm['organisation.UnitMembership']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.unitmembership': {
+            'Meta': {'object_name': 'UnitMembership'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Person']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'unit': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Unit']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.workinggroup': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'WorkingGroup'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'homepage_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'incubation': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'theme': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Theme']", 'null': 'True', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['organisation']

--- a/foundation/organisation/models.py
+++ b/foundation/organisation/models.py
@@ -104,6 +104,9 @@ class Project(models.Model):
     sourcecode_url = models.URLField(blank=True)
     mailinglist_url = models.URLField(blank=True)
 
+    featured = models.BooleanField(
+        default=False,
+        help_text="Should this be a featured project?")
     themes = models.ManyToManyField('Theme', blank=True)
     types = models.ManyToManyField('ProjectType', blank=True)
 
@@ -122,6 +125,7 @@ class ProjectType(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     name = models.CharField(max_length=100)
+    slug = models.SlugField(max_length=100, unique=True)
 
     def __unicode__(self):
         return self.name

--- a/foundation/organisation/templates/organisation/project_list.html
+++ b/foundation/organisation/templates/organisation/project_list.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load cms_tags %}
 {% load markdown_deux_tags %}
+{% load thumbnail %}
 
 {% block body-class %}projects{% endblock %}
 
@@ -12,15 +13,59 @@
   {% static_placeholder "projects intro" %}
 </div>
 <div class="row">
-  <div class="main col-md-12">
-    {% for project in object_list %}
-      <h3>{{ project.name }}</h3>
-      {{ project.description|markdown }}
-    {% empty %}
-    <p>{% trans 'No projects found.' %}</p>
-    {% endfor %}
-
-    {% include "includes/pager.html" %}
+  <div class="col-md-5 col-md-push-7">
+    <div class="project-filter pull-right">
+      Filter by:
+      <a href="?filter=popular" class="btn btn-default{% if request.GET.filter == 'popular' %} active{% endif %}">Popular</a>
+      <div class="btn-group">
+        <a href="#" class="btn btn-default dropdown-toggle{% if 'theme' in request.GET %} active {% endif %}" data-toggle="dropdown">
+          Theme <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu" role="menu">
+          {% for theme in themes %}
+          <li{% if request.GET.theme == theme.slug %} class="active"{% endif %}><a href="?theme={{ theme.slug }}">{{ theme.name }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div class="btn-group">
+        <button type="button" class="btn btn-default dropdown-toggle{% if 'type' in request.GET%} active{% endif %}" data-toggle="dropdown">
+          Type <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu" role="menu">
+          {% for projecttype in projecttypes %}
+          <li{% if request.GET.type == projecttype.slug %} class="active"{% endif %}><a href="?type={{ projecttype.slug }}">{{ projecttype.name|capfirst }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
   </div>
 </div>
+<div class="row">
+  {% for project in object_list %}
+  <div class="project col-md-4 col-xs-12">
+    <a href="{% url 'project' slug=project.slug %}" title="{{ project.name }}">
+      {% if project.banner %}
+      <h3 class="sr-only">{{ project.name }}</h3>
+      {% thumbnail project.banner "375" format="PNG" as im %}
+      <img class="img-responsive"
+           src="{{ im.url }}"
+           alt="Banner for {{ project.name }}">
+      {% endthumbnail %}
+      {% else %}
+      <h3>{{ project.name }}</h3>
+      {% endif %}
+    </a>
+    <p class="featured-project-teaser">{{ project.teaser }}</p>
+    <a href="{% url 'project' slug=project.slug %}"
+       title="{{ project.name }}"
+       class="btn btn-default"
+       role="button">
+      Find out more
+    </a>
+  </div>
+  {% empty %}
+  <p>{% trans 'No projects found.' %}</p>
+  {% endfor %}
+</div>
+{% include "includes/pager.html" %}
 {% endblock %}

--- a/static/less/main.less
+++ b/static/less/main.less
@@ -500,6 +500,26 @@ ul.icon-list {
   }
 }
 
+.projects {
+  .project {
+    margin-bottom: 20px;
+  }
+
+  .project-filter {
+    margin-bottom: 20px;
+
+    .btn.btn-default {
+      border:none;
+
+    }
+
+    .active, .dropdown-menu .active a {
+      background: #000000;
+      color: #ffffff;
+    }
+  }
+}
+
 // Make pictures uploaded by the CMS picture plugin responsive by default
 .plugin_picture img { .img-responsive; }
 

--- a/templates/includes/pager.html
+++ b/templates/includes/pager.html
@@ -2,12 +2,12 @@
 <ul class="pager">
   <li class="previous{% if not page_obj.has_previous %} disabled{% endif %}">
     <a href="{% if page_obj.has_previous %}?page={{ page_obj.previous_page_number }}{% else %}#{% endif %}">
-      &larr; Newer
+      &larr; {% if timeless %}Previous{% else %}Newer{% endif %}
     </a>
   </li>
   <li class="next{% if not page_obj.has_next %} disabled{% endif %}">
     <a href="{% if page_obj.has_next %}?page={{ page_obj.next_page_number }}{% else %}#{% endif %}">
-      Older &rarr;
+      {% if timeless %}Next{% else %}Older{% endif %} &rarr;
     </a>
   </li>
 </ul>


### PR DESCRIPTION
The project list was just that, a list of project names and their
descriptions. Some projects have a banner image which can help
them stand out so the list has now been changed into a more
gallery-like list where banners are shown where possible.

The gallery can be filtered by popular projects (marked by admins
to be featured, not algorithmically by number of click or such),
by themes, and by project types.

The filter solution is server generated using url parameters but
it can later be done via javascript and a project api to avoid
page reload... just not now. Now we only want a project gallery.

Fixes #63 
