### PR TITLE
organisation: show emails for members of network groups

### DIFF
--- a/foundation/organisation/templates/organisation/networkgroup_detail.html
+++ b/foundation/organisation/templates/organisation/networkgroup_detail.html
@@ -83,11 +83,9 @@
   </div>
   <div class="col-md-9">
     <h3>Core team</h3>
-    {% with skip_email=True %}
     {% for member in group_members %}
       {% include "organisation/member.html" %}
     {% endfor %}
-    {% endwith %}
 
     {% if object.extra_information %}
     <h3>More information</h3>


### PR DESCRIPTION
Network group members should have their emails available to allow
others to get in contact with them directly.

Fixes #144 
