### PR TITLE
organisation: add static placeholder to sidebar on board pages

### DIFF
--- a/foundation/organisation/templates/organisation/board_details.html
+++ b/foundation/organisation/templates/organisation/board_details.html
@@ -23,6 +23,7 @@
       <ul>{% for member in object.members.all %}
         <li><a href="#{{ member.name|slugify }}">{{ member.name }}</a></li>
       {% endfor %}</ul>
+      {% static_placeholder object.name|truncatechars:10|add:" (sidebar)" %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This allows content managers to add content to the sidebar of
board pages (e.g. minutes, terms of reference etc.

This solves partially #146 (content remaining).
