### PR TITLE
organisation: add active groups to working groups page sidebar

### DIFF
--- a/foundation/organisation/templates/organisation/workinggroup_list.html
+++ b/foundation/organisation/templates/organisation/workinggroup_list.html
@@ -45,6 +45,18 @@
     {% endfor %}
   </div>
   <div class="sidebar col-md-3 col-md-pull-9">
+    <h3>Active groups</h3>
+    {% static_placeholder "working groups active" %}
+    <ul>{% for workinggroup in active_list %}
+    <li>
+      <a href="{{ workinggroup.homepage_url }}" target="_blank">
+        {{ workinggroup.name }}
+      </a>
+    </li>
+    {% empty %}
+    <li>{% trans 'There are no active groups at the moment.' %}</li>
+    {% endfor %}</ul>
+
     <h3>Incubating groups</h3>
     {% static_placeholder "working groups incubating" %}
     <ul>{% for workinggroup in incubator_list %}

--- a/foundation/organisation/views.py
+++ b/foundation/organisation/views.py
@@ -74,6 +74,7 @@ class WorkingGroupListView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super(WorkingGroupListView, self).get_context_data(**kwargs)
+        context['active_list'] = WorkingGroup.objects.active()
         context['incubator_list'] = WorkingGroup.objects.incubators()
 
         return context


### PR DESCRIPTION
Since sidebar is placed to the left of the main content it makes
the incubating groups stand out more than the active groups. This
adds active groups to the sidebar as well, above the incubating
groups so that the active groups get more weight.

Fixes #155 
