### PR TITLE
Lessen the greed of network group urls

### DIFF
--- a/foundation/organisation/urls/networkgroups.py
+++ b/foundation/organisation/urls/networkgroups.py
@@ -1,14 +1,20 @@
 from django.conf.urls import patterns, url
+from django.utils.text import slugify
 
+from django_countries import countries
 from ..views import NetworkGroupDetailView, networkgroup_csv_output
+
+
+# Generate countries list for the regular expression (it shouldn't be greedy)
+COUNTRY_SLUGS = '|'.join([slugify(unicode(name)) for code, name in countries])
 
 
 urlpatterns = patterns(
     '',
-    url(r'^(?P<country>[^/]+)/$',
+    url(r'^(?P<country>'+COUNTRY_SLUGS+r')/$',
         NetworkGroupDetailView.as_view(),
         name='network-country'),
-    url(r'^(?P<country>[^/]+)/(?P<region>[^/]+)/$',
+    url(r'^(?P<country>'+COUNTRY_SLUGS+r')/(?P<region>[^/]+)/$',
         NetworkGroupDetailView.as_view(),
         name='network-region'),
     url(r'^csv$', networkgroup_csv_output, name='networkgroups-csv'),


### PR DESCRIPTION
Network group pages need to have subpages which are not accessible
due to the country url regular expression being too greedy. For it
to be less greedy we have to reduce the regular expression to a
list generated by django_countries (resulting in a large regular
expression).

Fixes #170 
