### PR TITLE
organisation: call Taiwan 'Taiwan' not 'Taiwan (Province of China)'

### DIFF
--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -16,6 +16,8 @@ from os import environ as env
 import dj_database_url
 from memcacheify import memcacheify
 
+from django.utils.translation import ugettext_lazy as _
+
 # Silence warnings from ipython/sqlite
 import warnings
 import exceptions
@@ -284,6 +286,11 @@ else:
 
 # Flag directory (uses flags from Open Icon Library)
 COUNTRIES_FLAG_URL = '/assets/img/flags/png/flag-{code}.png'
+
+# Override country names in django_countries
+COUNTRIES_OVERRIDE = {
+    'TW': _('Taiwan')
+}
 
 TEMPLATE_DEBUG = DEBUG
 


### PR DESCRIPTION
This is done via an override in foundation/settings.py because of
how django_countries is customised.

Fixes #174 
