### PR TITLE
Pluralize group types for network groups

### DIFF
--- a/foundation/organisation/templates/organisation/networkgroup_flags.html
+++ b/foundation/organisation/templates/organisation/networkgroup_flags.html
@@ -1,4 +1,4 @@
-<h3>{{ title }}</h3>
+<h3>{{ title }}{{ countries|length|pluralize }}</h3>
 <ul class="network-countries">{% for networkgroup in countries %}
 <li>
   <a href="{{ networkgroup.get_absolute_url }}" title="{{ networkgroup.name }}">


### PR DESCRIPTION
Adds an 's' (default for the templatetag) to the group types (chapter and local group)
when the number of elements are more than one.

Fixes #186 
