### PR TITLE
Allow ordering of members within units

### DIFF
--- a/foundation/organisation/migrations/0033_auto__add_field_unitmembership_order.py
+++ b/foundation/organisation/migrations/0033_auto__add_field_unitmembership_order.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'UnitMembership.order'
+        db.add_column(u'organisation_unitmembership', 'order',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'UnitMembership.order'
+        db.delete_column(u'organisation_unitmembership', 'order')
+
+
+    models = {
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        u'organisation.board': {
+            'Meta': {'object_name': 'Board'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Person']", 'through': u"orm['organisation.BoardMembership']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.boardmembership': {
+            'Meta': {'object_name': 'BoardMembership'},
+            'board': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Board']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Person']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.featuredproject': {
+            'Meta': {'object_name': 'FeaturedProject', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': u"orm['organisation.Project']"})
+        },
+        u'organisation.featuredtheme': {
+            'Meta': {'object_name': 'FeaturedTheme', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'theme': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': u"orm['organisation.Theme']"})
+        },
+        u'organisation.networkgroup': {
+            'Meta': {'ordering': "('country', 'region')", 'unique_together': "(('country', 'region'),)", 'object_name': 'NetworkGroup'},
+            'country': ('django_countries.fields.CountryField', [], {'max_length': '2'}),
+            'country_slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'extra_information': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'facebook_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'group_type': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'homepage_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mailinglist_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Person']", 'through': u"orm['organisation.NetworkGroupMembership']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'position': ('geoposition.fields.GeopositionField', [], {'default': "'0,0'", 'max_length': '42', 'null': 'True', 'blank': 'True'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'region_slug': ('django.db.models.fields.SlugField', [], {'default': 'None', 'max_length': '50'}),
+            'twitter': ('django.db.models.fields.CharField', [], {'max_length': '18', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'working_groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.WorkingGroup']", 'symmetrical': 'False', 'blank': 'True'}),
+            'youtube': ('django.db.models.fields.CharField', [], {'max_length': '18', 'blank': 'True'})
+        },
+        u'organisation.networkgrouplist': {
+            'Meta': {'object_name': 'NetworkGroupList', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'group_type': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        u'organisation.networkgroupmembership': {
+            'Meta': {'ordering': "['-order', 'person__name']", 'object_name': 'NetworkGroupMembership'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'networkgroup': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.NetworkGroup']"}),
+            'order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Person']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.person': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Person'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'photo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'twitter': ('django.db.models.fields.CharField', [], {'max_length': '18', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        u'organisation.project': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'Project'},
+            'banner': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'homepage_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mailinglist_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'picture': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'sourcecode_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'teaser': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'themes': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Theme']", 'symmetrical': 'False', 'blank': 'True'}),
+            'twitter': ('django.db.models.fields.CharField', [], {'max_length': '18', 'blank': 'True'}),
+            'types': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.ProjectType']", 'symmetrical': 'False', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.projectlist': {
+            'Meta': {'object_name': 'ProjectList', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'project_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.ProjectType']", 'null': 'True', 'blank': 'True'}),
+            'theme': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Theme']", 'null': 'True', 'blank': 'True'})
+        },
+        u'organisation.projecttype': {
+            'Meta': {'object_name': 'ProjectType'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.signupform': {
+            'Meta': {'object_name': 'SignupForm', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "'Get Connected to Open Knowledge'", 'max_length': '50'})
+        },
+        u'organisation.theme': {
+            'Meta': {'object_name': 'Theme'},
+            'blurb': ('django.db.models.fields.TextField', [], {}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'picture': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.unit': {
+            'Meta': {'ordering': "['-order', 'name']", 'object_name': 'Unit'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['organisation.Person']", 'through': u"orm['organisation.UnitMembership']", 'symmetrical': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.unitmembership': {
+            'Meta': {'ordering': "['-order', 'person__name']", 'object_name': 'UnitMembership'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Person']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'unit': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Unit']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'organisation.workinggroup': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'WorkingGroup'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'homepage_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'incubation': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'themes': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'workinggroups'", 'blank': 'True', 'to': u"orm['organisation.Theme']"}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['organisation']

--- a/foundation/organisation/models.py
+++ b/foundation/organisation/models.py
@@ -50,9 +50,15 @@ class UnitMembership(models.Model):
     title = models.CharField(max_length=100)
     person = models.ForeignKey('Person')
     unit = models.ForeignKey('Unit')
+    order = models.IntegerField(
+        blank=True, null=True,
+        help_text="Higher numbers mean higher up in the food chain")
 
     def __unicode__(self):
         return self.person.name + ' - ' + self.title
+
+    class Meta:
+        ordering = ["-order", "person__name"]
 
 
 class Board(models.Model):

--- a/foundation/organisation/tests/test_views.py
+++ b/foundation/organisation/tests/test_views.py
@@ -16,6 +16,10 @@ from ..models import (Board, Person, Project, Unit, Theme, WorkingGroup,
 @override_settings(ROOT_URLCONF='foundation.tests.urls')
 class UnitListViewTest(WebTest):
     def setUp(self):  # flake8: noqa
+        self.donatello = Person.objects.create(
+            name="Donatello (Donnie)",
+            description='Turtle with a purple mask',
+            email='donatello@tmnt.org')
         self.leonardo = Person.objects.create(
             name="Leonardo (Leo)",
             description='Turtle with a blue mask',
@@ -47,10 +51,16 @@ class UnitListViewTest(WebTest):
         self.footclan = Unit.objects.create(name="Foot Clan")
         self.masters = Unit.objects.create(name="Ninja Masters", order=1)
 
+        self.turtle_donatello = UnitMembership.objects.create(
+            title='Hacker',
+            person=self.donatello,
+            unit=self.turtles)
+
         self.turtle_leonardo = UnitMembership.objects.create(
             title='Leader',
             person=self.leonardo,
-            unit=self.turtles)
+            unit=self.turtles,
+            order=1)
 
         self.turtle_raphael = UnitMembership.objects.create(
             title='Bad boy',
@@ -84,16 +94,20 @@ class UnitListViewTest(WebTest):
 
     def test_unit_members_in_units(self):
         response = self.app.get(reverse('units'))
-        footclan = response.body.find(self.footclan.name)
-        turtles = response.body.find(self.turtles.name)
 
         # Units are ordered alphabetically
+        footclan = response.body.find(self.footclan.name)
+        turtles = response.body.find(self.turtles.name)
         self.assertTrue(footclan < turtles)
+
+        # Unit members are ordered alphabetically
+        # unless order is overwritten
+        donatello = response.body.find(self.donatello.name)
         leonardo = response.body.find(self.leonardo.name)
         raphael = response.body.find(self.raphael.name)
         rocksteady = response.body.find(self.rocksteady.name)
         self.assertTrue(footclan < rocksteady < turtles)
-        self.assertTrue(turtles < leonardo < raphael)
+        self.assertTrue(turtles < leonardo < donatello < raphael)
 
     def test_description_in_response(self):
         response = self.app.get(reverse('units'))


### PR DESCRIPTION
This uses the "order" field convention where members with higher
numbers are shown first (no number at the bottom) else the members
are ordered by their person's name.

Fixes #175 
