### PR TITLE
search: add links to project's search results

### DIFF
--- a/foundation/organisation/templates/search/organisation/project.html
+++ b/foundation/organisation/templates/search/organisation/project.html
@@ -1,9 +1,36 @@
 {% load markdown_deux_tags %}
 {% load thumbnail %}
 
-<h3>{{ project.name }}</h3>
+<h3><a href="{% url 'project' slug=project.slug %}">{{ project.name }}</a></h3>
 <div class="row">
   <div class="col-md-12">
     {{ project.description|markdown }}
+    <p>
+      {% if project.homepage_url %}
+      <a href='{{ project.homepage_url }}'
+         title='Project homepage'>
+        <i class='fa fa-home fa-lg fa-fw'></i> Homepage
+      </a>
+      {% endif %}
+      {% if project.mailinglist_url %}
+      <a href='{{ project.mailinglist_url }}'
+         title='Project mailing list'>
+        <i class='fa fa-envelope fa-lg fa-fw'></i> Mailing list
+      </a>
+      {% endif %}
+      {% if project.twitter %}
+      <a href='https://twitter.com/{{ project.twitter }}'
+         title='@{{ project.twitter }} on Twitter'>
+        <i class='fa fa-twitter fa-lg fa-fw twitter'></i>
+        @{{ project.twitter }}
+      </a>
+      {% endif %}
+      {% if project.sourcecode_url %}
+      <a href='{{ project.sourcecode_url }}'
+         title='Project source code'>
+        <i class='fa fa-code fa-lg fa-fw'></i> Source code
+      </a>
+      {% endif %}
+    </p>
   </div>
 </div>


### PR DESCRIPTION
Project search result should give all of the most important links
in the search result itself, and link to the project overview page
served by foundation.

Fixes #165 
