### PR TITLE
[#235] change content_type check in results.html

### DIFF
--- a/foundation/search/templates/search/results.html
+++ b/foundation/search/templates/search/results.html
@@ -1,4 +1,4 @@
-{% if search_result.content_type == 'aldryn_search.titleproxy' %}
+{% if search_result.content_type == 'cms.title' %}
   {% with cms=search_result.object result=search_result %}
     {% include "search/cms/page.html" %}
   {% endwith %}


### PR DESCRIPTION
Fixes #235 

Changing the content type already helped. Previously the search would sometimes return results but they would not be displayed because the `content_type` that was checked as `aldryn_search.titleproxy` should have been `cms.title`.

The question remains why the search finds things locally but not on production. I would also love to add a test for this.