### PR TITLE
Add robots.txt

### DIFF
--- a/foundation/urls.py
+++ b/foundation/urls.py
@@ -15,7 +15,10 @@ urlpatterns = patterns(
     '',
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/', include(admin.site.urls)),
-    )
+    url(r'^robots.txt$', TemplateView.as_view(template_name="robots.txt",
+                                              content_type="text/plain"),
+        name="robots_file")
+)
 
 # Allow testing of error pages in development
 if settings.DEBUG:

--- a/templates/robots.txt
+++ b/templates/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Host: okfn.org
+Sitemap: https://okfn.org/sitemap.xml


### PR DESCRIPTION
Fixes #233 

This is the easiest possible version. I hardcoded the site name. We could of course also use django to find out the current base uri and construct the full path for `Host` and `Sitemap`. Would love to know what you think @pwalsh 
