### PR TITLE
Add oembed plugin

### DIFF
--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -112,6 +112,7 @@ INSTALLED_APPS = (
     'djangocms_picture',
     'djangocms_link',
     'djangocms_text_ckeditor',
+    'djangocms_oembed',
     'aldryn_search',
 
     # CMS

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ djangocms-admin-style==1.1.0
 djangocms-file==1.0
 djangocms-googlemap==0.4.0
 djangocms-link==1.7
+git+git://github.com/divio/djangocms-oembed.git
 djangocms-picture==1.0.0
 djangocms-text-ckeditor==3.0.0
 gunicorn==19.4.5


### PR DESCRIPTION
Fixes #109

This is branched of #290. Only merge after merging that one.

This adds the `djangocms_oembed` plugin that allows embedding videos and such with the djangocms editor. 

Unfortunately there is a bug in the latest version that was published on PyPi so it is necessary to install from github.

Again, this required the migrations to be run after deployment.