### PR TITLE
Use aldryn-video for oembed

### DIFF
--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -177,7 +177,7 @@ TEMPLATES = [
                     ),
                 'loaders': [
                     'django.template.loaders.filesystem.Loader',
-                    'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
+                    'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',  # nopep8
                     'django.template.loaders.app_directories.Loader',
                     ],
                 }

--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -112,7 +112,9 @@ INSTALLED_APPS = (
     'djangocms_picture',
     'djangocms_link',
     'djangocms_text_ckeditor',
+    'aldryn_boilerplates',
     'aldryn_search',
+    'aldryn_video',
 
     # CMS
     'cms',
@@ -152,7 +154,6 @@ MIDDLEWARE_CLASSES = (
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'OPTIONS': {
             'debug': DEBUG,
@@ -172,10 +173,25 @@ TEMPLATES = [
                     'lib.context_processors.google_analytics',
                     'lib.context_processors.mailchimp',
                     'django.template.context_processors.request',
-                ),
-            }
+                    'aldryn_boilerplates.context_processors.boilerplate',
+                    ),
+                'loaders': [
+                    'django.template.loaders.filesystem.Loader',
+                    'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
+                    'django.template.loaders.app_directories.Loader',
+                    ],
+                }
     },
 ]
+
+STATICFILES_FINDERS = (
+        'django.contrib.staticfiles.finders.FileSystemFinder',
+        'aldryn_boilerplates.staticfile_finders.AppDirectoriesFinder',
+        'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+        )
+
+ALDRYN_BOILERPLATE_NAME = 'bootstrap3'
+
 
 ROOT_URLCONF = 'foundation.urls'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 Django==1.8.12
 Pillow==3.2.0
 aldryn-search==0.2.12
+git+git://github.com/aldryn/aldryn-video
 boto==2.39.0
 cssmin==0.2.0
 dj-database-url==0.4.0


### PR DESCRIPTION
Fixes #109 

As mentioned already `djangocms_oembed` was not update in quite some time and seems not to work with the lastet `django-cms` anymore. As far as I can tell `aldryn-video` is a fork of this with some more recent updates and some `aldryn` magic.

This requires use to use the `aldyrn_boilterplate` plugin (a dependency of `aldryn_video`) and make some changes to our `settings.py` file. I don't really like this but it seems like the best option at the time. Unfortunately documentation for both of the plugins is pretty nonexistant...