### PR TITLE
Add django cms rss plugin

### DIFF
--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -115,6 +115,7 @@ INSTALLED_APPS = (
     'aldryn_boilerplates',
     'aldryn_search',
     'aldryn_video',
+    'rssplugin',
 
     # CMS
     'cms',

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ django-pagedown==0.1.1
 django-pylibmc-sasl==0.2.4
 #django-reversion==1.8.5
 django-reversion==1.10.1
+django-rss-plugin==0.1.0
 django-s3-folder-storage==0.3
 django-secure==1.0.1
 django-sekizai==0.9.0


### PR DESCRIPTION
This adds a plugin that allows including rss feeds.

Adding the actual feed from http://blog.okfn.org/feed/ should then be done through the in page editor.