### PR TITLE
[#304] Remove unused field from networkgroup

### DIFF
--- a/foundation/organisation/migrations/0003_remove_fields_from_networkgroup.py
+++ b/foundation/organisation/migrations/0003_remove_fields_from_networkgroup.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('organisation', '0002_sidebarextension'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='networkgroup',
+            name='gplus_url',
+        ),
+        migrations.RemoveField(
+            model_name='networkgroup',
+            name='wiki_url',
+        ),
+        migrations.RemoveField(
+            model_name='networkgroup',
+            name='youtube_url',
+        ),
+    ]

--- a/foundation/organisation/migrations/0004_remove_fields_from_networkgroup.py
+++ b/foundation/organisation/migrations/0004_remove_fields_from_networkgroup.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('organisation', '0002_sidebarextension'),
+        ('organisation', '0003_add_nowdoing_field'),
     ]
 
     operations = [

--- a/foundation/organisation/models.py
+++ b/foundation/organisation/models.py
@@ -249,9 +249,6 @@ class NetworkGroup(models.Model):
     homepage_url = models.URLField(blank=True)
     twitter = models.CharField(max_length=18, blank=True)
     facebook_url = models.URLField(blank=True)
-    youtube_url = models.URLField(blank=True)
-    gplus_url = models.URLField('Google+ url', blank=True)
-    wiki_url = models.URLField(blank=True)
 
     position = GeopositionField(blank=True, null=True)
 

--- a/foundation/organisation/templates/organisation/networkgroup_detail.html
+++ b/foundation/organisation/templates/organisation/networkgroup_detail.html
@@ -33,12 +33,6 @@
         <a href="{{ object.homepage_url }}">{{ object.homepage_url }}</a>
       </li>
       {% endif %}
-      {% if object.wiki_url %}
-      <li>
-        <i class="fa fa-link fa-large"></i>
-        <a href="{{ object.wiki_url }}">Wiki page</a>
-      </li>
-      {% endif %}
       {% if object.mailinglist_url %}
       <li>
         <i class="fa fa-envelope fa-large"></i>
@@ -58,22 +52,6 @@
         <i class="fa fa-facebook-square fa-large"></i>
         <a href="{{ object.facebook_url }}">
           Facebook page
-        </a>
-      </li>
-      {% endif %}
-      {% if object.gplus_url %}
-      <li>
-        <i class="fa fa-google-plus fa-large"></i>
-        <a href="{{ object.gplus_url }}">
-          Google+ page
-        </a>
-      </li>
-      {% endif %}
-      {% if object.youtube_url %}
-      <li>
-        <i class="fa fa-youtube fa-large"></i>
-        <a href="{{ object.youtube_url }}">
-          YouTube channel
         </a>
       </li>
       {% endif %}

--- a/foundation/organisation/templates/search/organisation/networkgroup.html
+++ b/foundation/organisation/templates/search/organisation/networkgroup.html
@@ -32,12 +32,6 @@
         Facebook page
       </a>
       {% endif %}
-      {% if object.youtube_url %}
-      <i class="fa fa-youtube fa-large"></i>
-      <a href="{{ object.youtube_url }}">
-        YouTube channel
-      </a>
-      {% endif %}
     </p>
   </div>
 </div>

--- a/foundation/organisation/tests/test_cms_plugins.py
+++ b/foundation/organisation/tests/test_cms_plugins.py
@@ -130,7 +130,6 @@ class NetworkGroupPluginTest(CMSTestCase):
             homepage_url='http://queen.okfn.org/',
             twitter='buckingham',
             facebook_url='http://facebook.com/queenthepersonnottheband',
-            youtube_url='https://www.youtube.com/user/Queenovision'
             )
 
         self.germany = NetworkGroup.objects.create(

--- a/foundation/organisation/tests/test_views.py
+++ b/foundation/organisation/tests/test_views.py
@@ -451,7 +451,6 @@ class NetworkGroupDetailViewTest(WebTest):
             country='GB',
             mailinglist_url='http://lists.okfn.org/okfn-britain',
             homepage_url='http://gb.okfn.org/',
-            wiki_url='http://wiki.okfn.org/GodSaveTheQueen',
             twitter='OKFNgb'
             )
 
@@ -465,8 +464,6 @@ class NetworkGroupDetailViewTest(WebTest):
             homepage_url='http://queen.okfn.org/',
             twitter='buckingham',
             facebook_url='http://facebook.com/queenthepersonnottheband',
-            youtube_url='https://www.youtube.com/user/Queenovision',
-            gplus_url='https://plus.google.com/+Intel',
             )
 
 
@@ -546,13 +543,10 @@ class NetworkGroupDetailViewTest(WebTest):
 
         self.assertIn(self.buckingham.homepage_url, response.body)
         self.assertNotIn(self.britain.homepage_url, response.body)
-        self.assertNotIn(self.britain.wiki_url, response.body)
         self.assertNotIn(self.britain.mailinglist_url, response.body)
         self.assertIn(self.buckingham.twitter, response.body)
         self.assertNotIn(self.britain.twitter, response.body)
         self.assertIn(self.buckingham.facebook_url, response.body)
-        self.assertIn(self.buckingham.youtube_url, response.body)
-        self.assertIn(self.buckingham.gplus_url, response.body)
 
         self.assertIn(self.elizabeth.name, response.body)
         self.assertIn(self.elizabeth_britain.title, response.body)
@@ -603,8 +597,7 @@ class NetworkGroupDetailViewTest(WebTest):
         # Headers need to be on a specific form
         headers = ['ISO3', 'Country', 'Geo coordinates', 'Map location',
                    'Local Groups status', 'Community Leaders', 'Website',
-                   'Wiki page', 'Mailing List', 'Twitter handle',
-                   'Youtube channel', 'Facebook page', 'Google+ page']
+                   'Mailing List', 'Twitter handle', 'Facebook page']
         for group in WorkingGroup.objects.all():
             headers.append('Topic: {0}'.format(group.name))
 
@@ -616,11 +609,8 @@ class NetworkGroupDetailViewTest(WebTest):
                         '', '', self.germany.get_group_type_display(),
                         ', '.join([m.name for m in self.germany.members.all()]),
                         self.germany.homepage_url,
-                        self.germany.wiki_url,
                         self.germany.mailinglist_url,
-                        self.germany.twitter, '', '',
-                        self.germany.gplus_url, 'Y', 'Y']
-
+                        self.germany.twitter, '', 'Y', 'Y']
         self.assertEqual(germany, germany_data)
 
         britain = csv.next()
@@ -629,11 +619,8 @@ class NetworkGroupDetailViewTest(WebTest):
                         '', '', self.britain.get_group_type_display(),
                         ', '.join([m.name for m in self.britain.members.all()]),
                         self.britain.homepage_url,
-                        self.britain.wiki_url,
                         self.britain.mailinglist_url,
-                        self.britain.twitter, '', '',
-                        self.britain.gplus_url, '', 'Y']
-        #import pdb; pdb.set_trace()
+                        self.britain.twitter, '', '', 'Y']
         self.assertEqual(britain, britain_data)
 
         buckingham = csv.next()
@@ -653,7 +640,6 @@ class NetworkGroupDetailViewTest(WebTest):
             self.buckingham.homepage_url,
             self.buckingham.mailinglist_url,
             self.buckingham.twitter,
-            self.buckingham.youtube_url,
             self.buckingham.facebook_url, 'Y', '' '']
 
     @override_settings(HUBOT_API_KEY='secretkey')

--- a/foundation/organisation/views.py
+++ b/foundation/organisation/views.py
@@ -164,8 +164,7 @@ def networkgroup_csv_output(request):
     writer = unicodecsv.writer(response)
     header_row = ['ISO3', 'Country', 'Geo coordinates', 'Map location',
                   'Local Groups status', 'Community Leaders', 'Website',
-                  'Wiki page', 'Mailing List', 'Twitter handle',
-                  'Youtube channel', 'Facebook page', 'Google+ page']
+                  'Mailing List', 'Twitter handle', 'Facebook page']
 
     working_groups = []
     for group in WorkingGroup.objects.all():
@@ -190,12 +189,9 @@ def networkgroup_csv_output(request):
                u', '.join([member.name
                           for member in group.members.all()]),  # Leaders
                group.homepage_url,  # Website
-               group.wiki_url if group.wiki_url else '',
                group.mailinglist_url,
                group.twitter if group.twitter else '',
-               group.youtube_url if group.youtube_url else '',
-               group.facebook_url,
-               group.gplus_url if group.gplus_url else '', ]
+               group.facebook_url]
 
         # Find topics of working group
         group_working_groups = [g.name for g in group.working_groups.all()]


### PR DESCRIPTION
Fixes #304 

This removes three fields from `NetworkGroups`
- youtube_url
- wiki_url
- gplus_url

They were not used by any groups so it was decided that they can be
dropped