### PR TITLE
add extra group_type options to NetworkGroup.

### DIFF
--- a/foundation/organisation/migrations/0009_auto_20161109_1319.py
+++ b/foundation/organisation/migrations/0009_auto_20161109_1319.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('organisation', '0008_auto_20160707_0752'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='networkgroup',
+            name='group_type',
+            field=models.IntegerField(default=0, choices=[(0, b'Local group'), (1, b'Chapter'), (2, b'Established group'), (3, b'Incubating group'), (4, b'Hibernated group'), (5, b'Affiliate')]),
+        ),
+        migrations.AlterField(
+            model_name='networkgrouplist',
+            name='group_type',
+            field=models.IntegerField(default=0, choices=[(0, b'Local group'), (1, b'Chapter'), (2, b'Established group'), (3, b'Incubating group'), (4, b'Hibernated group'), (5, b'Affiliate')]),
+        ),
+    ]

--- a/foundation/organisation/models.py
+++ b/foundation/organisation/models.py
@@ -273,7 +273,12 @@ class NetworkGroup(models.Model):
     objects = NetworkGroupManager()
 
     GROUP_TYPES = ((0, 'Local group'),
-                   (1, 'Chapter'))
+                   (1, 'Chapter'),
+                   (2, 'Established group'),
+                   (3, 'Incubating group'),
+                   (4, 'Hibernated group'),
+                   (5, 'Affiliate')
+                   )
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)


### PR DESCRIPTION
FIx #266.

This PR extends the NetworkGroup plugin with extra group types to choose from.
Adding them to the website is off course done through the CMS Plugin system.
If there's a problem with the positioning of the elements in the page, this will be a problem in the used template, and will need to be addressed (but in a different issue-pr).

CC: @morchickit