### PR TITLE
Feature/add blogfeed author image

### DIFF
--- a/foundation/blogfeed/cms_plugins.py
+++ b/foundation/blogfeed/cms_plugins.py
@@ -13,14 +13,13 @@ class FeedDisplayPlugin(CMSPluginBase):
     name = _("Latest Blogposts")
 
     def _get_three_articles(self):
-        feed_url = 'https://blog.okfn.org/feed/'
+        feed_url = 'https://blog.okfn.org/?feed=enclosure'
         feed = feedparser.parse(feed_url)
         return feed.entries[:3]
 
     def render(self, context, instance, placeholder):
         context = super(FeedDisplayPlugin, self)\
             .render(context, instance, placeholder)
-
         context['entries'] = self._get_three_articles()
         return context
 

--- a/foundation/blogfeed/templates/hello_plugin.html
+++ b/foundation/blogfeed/templates/hello_plugin.html
@@ -3,7 +3,9 @@
     {% for entry in entries %}
         {% with entry.enclosures|first as author_image_enclosure %}
             <article>
-                <img class="avatar" src="{{ author_image_enclosure.href }}" alt="{{ entry.author }}"/>
+                <img class="avatar"
+                     src="{% if author_image_enclosure %}{{ author_image_enclosure.href }}{% else %}{% static 'img/avatar-none.png' %}{% endif %}"
+                     alt="{{ entry.author }}"/>
                 <h4><a href='{{ entry.link }}'>{{ entry.title }}</a></h4>
                 <p>
                     {{ entry.summary|safe }}

--- a/foundation/blogfeed/templates/hello_plugin.html
+++ b/foundation/blogfeed/templates/hello_plugin.html
@@ -1,12 +1,14 @@
 {% load staticfiles %}
 <div>
     {% for entry in entries %}
-        <article>
-            <img class="avatar" src="{% static 'img/avatar-none.png' %}" alt="{{ entry.author }}"/>
-            <h4><a href='{{ entry.link }}'>{{ entry.title }}</a></h4>
-            <p>
-                {{ entry.summary| safe }}
-            </p>
-        </article>
+        {% with entry.enclosures|first as author_image_enclosure %}
+            <article>
+                <img class="avatar" src="{{ author_image_enclosure.href }}" alt="{{ entry.author }}"/>
+                <h4><a href='{{ entry.link }}'>{{ entry.title }}</a></h4>
+                <p>
+                    {{ entry.summary|safe }}
+                </p>
+            </article>
+        {% endwith %}
     {% endfor %}
 </div>


### PR DESCRIPTION
Fix #318.

Changes introduced:

- change the RSS feed url to point to the new feed that includes images.
- consume this feed and add author images.
- if an image is missing, use the current default.