### PR TITLE
fix bad html escaping of blogfeed snippet text on homepage

### DIFF
--- a/foundation/blogfeed/templates/hello_plugin.html
+++ b/foundation/blogfeed/templates/hello_plugin.html
@@ -1,12 +1,12 @@
 {% load staticfiles %}
 <div>
-  {% for entry in entries %}
-  <article>
-    <img class="avatar" src="{% static 'img/avatar-none.png' %}" alt="{{entry.author}}" />
-    <h4><a href='{{entry.link}}'>{{entry.title}}</a></h4>
-    <p>
-      {{entry.summary}}
-    </p>
-  </article>
-  {% endfor %}
+    {% for entry in entries %}
+        <article>
+            <img class="avatar" src="{% static 'img/avatar-none.png' %}" alt="{{ entry.author }}"/>
+            <h4><a href='{{ entry.link }}'>{{ entry.title }}</a></h4>
+            <p>
+                {{ entry.summary| safe }}
+            </p>
+        </article>
+    {% endfor %}
 </div>


### PR DESCRIPTION
This fixes #333 

- mark entry.summary text as html safe.
- It is safe by default, since we are using pyhthon-feedparser. see: http://pythonhosted.org/feedparser/html-sanitization.html#advanced-sanitization