### PR TITLE
add columns to network group element.

### DIFF
--- a/foundation/organisation/templates/organisation/networkgroup_flags.html
+++ b/foundation/organisation/templates/organisation/networkgroup_flags.html
@@ -1,10 +1,11 @@
-<h3>{{ title }}{{ countries|length|pluralize }}</h3>
-<ul class="network-countries">{% for networkgroup in countries %}
-<li>
-  <a href="{{ networkgroup.get_absolute_url }}" title="{{ networkgroup.name }}">
-    <img class="flag" src="{{ networkgroup.country.flag }}" alt="{{ networkgroup.name }}">
-    {{ networkgroup.get_country_display }}
-  </a>
-</li>
-{% endfor %}</ul>
-
+<div class="col-md-4 col-xs-12">
+    <h3>{{ title }}{{ countries|length|pluralize }}</h3>
+    <ul class="network-countries">{% for networkgroup in countries %}
+        <li>
+            <a href="{{ networkgroup.get_absolute_url }}" title="{{ networkgroup.name }}">
+                <img class="flag" src="{{ networkgroup.country.flag }}" alt="{{ networkgroup.name }}">
+                {{ networkgroup.get_country_display }}
+            </a>
+        </li>
+    {% endfor %}</ul>
+</div>


### PR DESCRIPTION
This is a subtask of #266.

- Columns are not added in a different context, and without it the design comes out wrong.