### PR TITLE
fix jquery load error

### DIFF
--- a/templates/general.html
+++ b/templates/general.html
@@ -176,14 +176,14 @@
                     $('#side-nav').animate({height: totalHeight}, 400);
                 }
 
-                (function () {
+                (function loadMenuWithScreenSizeAwareness() {
                     var hamBurgerButton = document.getElementsByClassName('show-menu')[0];
                     var display = window.getComputedStyle(hamBurgerButton, null).getPropertyValue("display");
                     var bigScreen = (display === 'none');
-                    var navigationVisible = ($('#side-nav > ul').length) > 0
+                    var navigationVisible = ($('#side-nav > ul').length) > 0;
                     if (bigScreen & navigationVisible) {
                         loadScript('{{ STATIC_URL }}vendor/jQuery.mmenu/dist/js/jquery.mmenu.oncanvas.min.js');
-                        $(window).load(function () {
+                        $(window).on('load', function () {
                             $("#side-nav").mmenu({
                                 // options
                             }, {
@@ -193,7 +193,7 @@
                                 },
                                 "offCanvas": false
                             });
-                            $('#side-nav').css('display', 'block')
+                            $('#side-nav').css('display', 'block');
                             resizeNavBar();
 
                             api = $("#side-nav").data("mmenu");
@@ -202,7 +202,7 @@
                     }
                     else {
                         loadScript('{{ STATIC_URL }}vendor/jQuery.mmenu/dist/js/jquery.mmenu.min.js');
-                        $(window).load(function () {
+                        $(window).on('load', function () {
                             $("#mmenu").mmenu({
                                 // options
                                 offCanvas: {
@@ -218,7 +218,7 @@
                             });
                         });
                     }
-                })()
+                })();
 
                 //external links
                 $('a[rel*=external]').click(function () {


### PR DESCRIPTION
fix #350

- refactor jquery.load calls to jquery.on('load'):
- This is required in jQuery >=3.0.0 .
- This solves a problem in loading the navigation menu.