### PR TITLE
Link travis badge to correct url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the [Django][dj]/[Django CMS][djcms] project that runs <http://okfn.org>
 [dj]: https://www.djangoproject.com/
 [djcms]: https://www.django-cms.org/
 
-[![Build Status](https://travis-ci.org/okfn/website.svg?branch=master)](https://travis-ci.org/okfn/foundation)
+[![Build Status](https://travis-ci.org/okfn/website.svg?branch=master)](https://travis-ci.org/okfn/website)
 [![Coverage Status](https://coveralls.io/repos/github/okfn/website/badge.svg?branch=master)](https://coveralls.io/github/okfn/website?branch=master)
 
 ## Prerequisites and assumptions


### PR DESCRIPTION
The repo name changed from `foundation` to `website`. This commit just fixes the broken travis badge link in the README.