### PR TITLE
reorder member statuses according to requirements.

### DIFF
--- a/foundation/organisation/models.py
+++ b/foundation/organisation/models.py
@@ -22,6 +22,8 @@ class Person(models.Model):
     twitter = models.CharField(max_length=18, blank=True)
     url = models.URLField(blank=True)
 
+    NOWDOING_DEFAULT_ORDER = ('working', 'location', 'reading', 'listening', 'watching', 'eating')
+
     def __unicode__(self):
         return self.name
 
@@ -40,6 +42,16 @@ class Person(models.Model):
         if nowdoings:
             nowdoings[0].is_newest_update = True
         return nowdoings
+
+    @property
+    def nowdoing_by_custom_order(self, custom_order=None):
+        custom_order = custom_order or self.NOWDOING_DEFAULT_ORDER
+        nowdoings = self.nowdoing_with_latest
+        ordered_nowdoings = list()
+        for doing_type in custom_order:
+            if nowdoings.filter(doing_type=doing_type):
+                ordered_nowdoings.append(nowdoings.filter(doing_type=doing_type).first())
+        return ordered_nowdoings
 
     @property
     def has_anything_to_show(self):
@@ -62,7 +74,7 @@ class NowDoing(models.Model):
         ('location', 'location'),
         ('watching', 'watching'),
         ('eating', 'eating'),
-        )
+    )
     person = models.ForeignKey(Person)
     doing_type = models.CharField(
         max_length=10,
@@ -87,7 +99,7 @@ class NowDoing(models.Model):
             'location': 'Location',
             'watching': 'Watching',
             'eating': 'Eating'
-            }
+        }
         return matching.get(self.doing_type, self.doing_type)
 
     def __repr__(self):
@@ -224,7 +236,6 @@ class Theme(models.Model):
 
 
 class WorkingGroupManager(models.Manager):
-
     def active(self):
         return self.get_queryset().filter(incubation=False)
 
@@ -260,12 +271,11 @@ class WorkingGroup(models.Model):
 
 
 class NetworkGroupManager(models.Manager):
-
     def countries(self):
         return self.get_queryset().filter(region_slug='')
 
     def regions(self, country):
-        return self.get_queryset().exclude(region_slug='')\
+        return self.get_queryset().exclude(region_slug='') \
             .filter(country_slug=country)
 
 
@@ -347,7 +357,7 @@ class NetworkGroupMembership(models.Model):
     order = models.IntegerField(
         blank=True, null=True,
         help_text="The lower the number the higher on the"
-        " page this Person will be shown.")
+                  " page this Person will be shown.")
     networkgroup = models.ForeignKey('NetworkGroup')
     person = models.ForeignKey('Person')
 

--- a/foundation/organisation/models.py
+++ b/foundation/organisation/models.py
@@ -22,7 +22,9 @@ class Person(models.Model):
     twitter = models.CharField(max_length=18, blank=True)
     url = models.URLField(blank=True)
 
-    NOWDOING_DEFAULT_ORDER = ('working', 'location', 'reading', 'listening', 'watching', 'eating')
+    NOWDOING_DEFAULT_ORDER = (
+        'working', 'location', 'reading', 'listening', 'watching', 'eating'
+    )
 
     def __unicode__(self):
         return self.name
@@ -50,7 +52,8 @@ class Person(models.Model):
         ordered_nowdoings = list()
         for doing_type in custom_order:
             if nowdoings.filter(doing_type=doing_type):
-                ordered_nowdoings.append(nowdoings.filter(doing_type=doing_type).first())
+                ordered_nowdoings.append(
+                    nowdoings.filter(doing_type=doing_type).first())
         return ordered_nowdoings
 
     @property

--- a/foundation/organisation/templates/organisation/member.html
+++ b/foundation/organisation/templates/organisation/member.html
@@ -13,36 +13,16 @@
                 <p class="job-title">{{ member.title }}</p>
             {% endif %}
             {{ person.description|markdown }}
-
+            {% with a=person.all_now_doing_by_type %}
+                <p>{% if a.watching %}{{ a.watching }}{% endif %}</p>
+            {% endwith %}
             {% if person.has_anything_to_show or person.email and not skip_email %}
                 <div class="meta">
                     <div class="tab-content">
 
-                        {% if person.email and not skip_email %}
+                        {% for doing in person.nowdoing_by_custom_order %}
                             <div role="tabpanel"
-                                 class="tab-pane active"
-                                 id="{{ person.name|slugify }}-email">
-                                <h4>Email:</h4>
-                                {{ person.email }}
-                            </div>
-                        {% endif %}
-                        {% if person.twitter %}
-                            <div role="tabpanel" class="tab-pane" id="{{ person.name|slugify }}-twitter">
-                                <h4>Twitter:</h4>
-                                <a href="https://twitter.com/{{ person.twitter }}"> {{ person.twitter }} </a>
-                            </div>
-                        {% endif %}
-
-                        {% if person.url %}
-                            <div role="tabpanel" class="tab-pane" id="{{ person.name|slugify }}-home">
-                                <h4>Homepage:</h4>
-                                <a href="{{ person.url }}"> {{ person.url }}</a>
-                            </div>
-                        {% endif %}
-
-                        {% for doing in person.nowdoing_with_latest %}
-                            <div role="tabpanel"
-                                 class="tab-pane"
+                                 class="tab-pane {% if doing.is_newest_update %}active{% endif %}"
                                  id="{{ person.name|slugify }}-{{ doing.doing_type }}">
                                 <h4>{{ doing.display_name }}:</h4>
                                 {% if doing.link %}
@@ -53,21 +33,43 @@
                             </div>
                         {% endfor %}
 
+                        {% if person.twitter %}
+                            <div role="tabpanel" class="tab-pane" id="{{ person.name|slugify }}-twitter">
+                                <h4>Twitter:</h4>
+                                <a href="https://twitter.com/{{ person.twitter }}"> {{ person.twitter }} </a>
+                            </div>
+                        {% endif %}
+                        {% if person.url %}
+                            <div role="tabpanel" class="tab-pane" id="{{ person.name|slugify }}-home">
+                                <h4>Homepage:</h4>
+                                <a href="{{ person.url }}"> {{ person.url }}</a>
+                            </div>
+                        {% endif %}
 
+                        {% if person.email and not skip_email %}
+                            <div role="tabpanel"
+                                 class="tab-pane {% if not person.nowdoing_by_custom_order %}active{% endif %}"
+                                 id="{{ person.name|slugify }}-email">
+                                <h4>Email:</h4>
+                                {{ person.email }}
+                            </div>
+                        {% endif %}
                     </div>
 
                     <ul class="nav nav-tabs" role="tablist">
-                        {% if person.email and not skip_email %}
-                            <li role="presentation" class="active">
-                                <a href="#{{ person.name|slugify }}-email"
-                                   aria-controls="{{ person.name|slugify }}-email"
+
+                        {% for doing in person.nowdoing_by_custom_order %}
+                            <li role="presentation" {% if doing.is_newest_update %} class="active" {% endif %}>
+                                <a href="#{{ person.name|slugify }}-{{ doing.doing_type }}"
+                                   aria-controls="{{ person.name|slugify }}-working"
                                    role="tab"
                                    data-toggle="tab">
-                                    <span class="icon-mail-circle" aria-hidden="true"></span>
-                                    <span class="sr-only">Email</span>
+                                    <span class="icon-{{ doing.icon_name }}-circle" aria-hidden="true"></span>
+                                    <span class="sr-only">{{ doing.doing_type }}</span>
                                 </a>
                             </li>
-                        {% endif %}
+                        {% endfor %}
+
                         {% if person.twitter %}
                             <li role="presentation"><a href="#{{ person.name|slugify }}-twitter"
                                                        aria-controls="{{ person.name|slugify }}-twitter" role="tab"
@@ -83,20 +85,17 @@
                                                                                aria-hidden="true"></span>
                                 <span class="sr-only">Home</span></a></li>
                         {% endif %}
-
-                        {% for doing in person.nowdoing_with_latest %}
-                            <li role="presentation">
-                                <a href="#{{ person.name|slugify }}-{{ doing.doing_type }}"
-                                   aria-controls="{{ person.name|slugify }}-working"
+                        {% if person.email and not skip_email %}
+                            <li role="presentation" {% if not person.nowdoing_by_custom_order %}class="active"{% endif %}>
+                                <a href="#{{ person.name|slugify }}-email"
+                                   aria-controls="{{ person.name|slugify }}-email"
                                    role="tab"
                                    data-toggle="tab">
-                                    <span class="icon-{{ doing.icon_name }}-circle" aria-hidden="true"></span>
-                                    <span class="sr-only">{{ doing.doing_type }}</span>
+                                    <span class="icon-mail-circle" aria-hidden="true"></span>
+                                    <span class="sr-only">Email</span>
                                 </a>
                             </li>
-                        {% endfor %}
-
-
+                        {% endif %}
                     </ul>
                 </div>
             {% endif %}


### PR DESCRIPTION
fix #323.

Changes introduced:
- add a utility method that orders the now_doing statuses according to supplied order.
- order the member template according to requested order.
- set active status to be the latest updated (or email, if none).