### PR TITLE
fix text wrapping on member description.

### DIFF
--- a/foundation/organisation/templates/organisation/member.html
+++ b/foundation/organisation/templates/organisation/member.html
@@ -4,7 +4,7 @@
 
 {% with person=member.person %}
     <div class="row">
-        <div class="profile container">
+        <div class="profile col-md-12">
             <span class="image" style="background-image: url(
                     {{ person.gravatar_url }}{% if person.photo %}&default={{ person.photo.url }}{% endif %});"><img
                     src="{% static 'img/blank.png' %}" alt=""/></span>


### PR DESCRIPTION
fix #337.

Changes introduced:
- handle text wrapping, without undoing earlier fix.