### PR TITLE
Change IP Policy to IM policy.

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -6,7 +6,7 @@
  </a>
  <ul class="footer-links">
    <li><a href="/privacy-policy/">Privacy policy</a></li>
-   <li><a href="/ip-policy/">IP policy</a></li>
+   <li><a href="/im-policy/">IM policy</a></li>
    <li><a href="/cookie-policy/">Cookie policy</a></li>
    <li><a href="/terms-of-use/">Terms of use</a></li>
    <li><a href="/about/jobs/">Jobs</a></li>


### PR DESCRIPTION
In order to better support the mission of "A World Where Knowledge Creates Power For The Many, Not The Few", I propose this commit, and the broader idea of changing all occurrences of the terms "Intellectual Property" to "Intellectual Monopoly".

The truth is Intellectual Monopoly laws are Intellectual Monopoly laws. Whether or not they are good or bad we can debate, but first we need to stop using dishonest terms promoted by the Few.

