### PR TITLE
Revert "Temp fix to apply migrations correctly to staging/prod DBs"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,4 @@ EXPOSE $PORT
 
 RUN python manage.py collectstatic --noinput
 
-CMD python manage.py migrate cms 0016 --settings foundation.temp_migration_settings &&\
-    python manage.py migrate easy_thumbnails &&\
-    python manage.py migrate &&\
-    python manage.py update_index &&\
-    /usr/bin/supervisord
+CMD python manage.py migrate && python manage.py update_index && /usr/bin/supervisord

--- a/foundation/temp_migration_settings.py
+++ b/foundation/temp_migration_settings.py
@@ -1,3 +1,0 @@
-from settings import *  # flake8: noqa
-INSTALLED_APPS = list(INSTALLED_APPS)
-INSTALLED_APPS.remove('aldryn_video')  # flake8: noqa


### PR DESCRIPTION
Now that we've applied this to the staging and production DBs we can revert this workaround.