### PR TITLE
remove some unnecessary packages

### DIFF
--- a/foundation/urls.py
+++ b/foundation/urls.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.conf.urls import include, url
+from django.conf.urls.static import static
 from django.views.generic import TemplateView
 from django.views.generic import RedirectView
 from django.contrib.auth import views as admin_views
@@ -116,3 +117,7 @@ urlpatterns += [
     # Fallthrough for CMS managed pages
     url(r'^', include('cms.urls'))
 ]
+
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/foundation/wsgi.py
+++ b/foundation/wsgi.py
@@ -2,15 +2,16 @@
 WSGI config for foundation project.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 """
 
 import os
+from os.path import abspath, dirname
+from sys import path
 from django.core.wsgi import get_wsgi_application
-from dj_static import Cling, MediaCling
+
+SITE_ROOT = dirname(dirname(abspath(__file__)))
+path.append(SITE_ROOT)
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "foundation.settings")
+
 application = get_wsgi_application()
-application = Cling(MediaCling(application))

--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,6 @@ gunicorn
 psycopg2
 pyelasticsearch>=0.6,<0.7 # required by django-haystack
 requests>=2.3,<2.4 # required by django-haystack
-static
 python-dotenv>0.8
 whoosh
 jsonfield==2

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,12 +40,8 @@ markdown2==2.3.1
 topicaxis-opengraph==0.5
 psycopg2==2.8.3
 elasticsearch==2.3.0
-pystache==0.5.4
 requests==2.9.1
-simplejson==3.8.2
 six==1.12.0
-static==1.1.1
-dj-static==0.0.6
 rcssmin==1.0.6
 rjsmin==1.1.0
 pytz==2018.4


### PR DESCRIPTION
- Static files can be served with django dispatcher in dev with minimal config and we use nginx/cloudfront in prod. We don't need third-party packages for this
- pystache is no longer used
- simplejson is no longer used