### PR TITLE
fail build if frontend not compiled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ install:
   - pip install coveralls
 script:
   - python manage.py makemigrations --check
+  - npx grunt sass:dist
+  - npx grunt postcss:dist
+  - npx grunt uglify:scripts
+  - git diff --exit-code static/
   - coverage run manage.py test
   - flake8 .
 after_success:


### PR DESCRIPTION
As seen in https://github.com/okfn/website/pull/482 it is possible to update front-end src or dependencies but forget to recompile.
It would be nice if we could detect when this has happened in CI and fail the build to avoid this error. Proposed solution here is run all the frontend compile tasks, then if `git diff` outputs anything, fail the build.. lets see.
This should fail in this PR, but then pass if we rebase on to #482 :crossed_fingers: 