### PR TITLE
Add action to publish image to DockerHub

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -9,6 +9,9 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+      - name: Get tag name
+        id: get_version
+        run: echo ::set-output name=TAG_NAME::$(echo $GITHUB_REF | cut -d / -f 3)
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -24,4 +27,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/website:latest
+          tags: openknowledge/website:${{ steps.get_version.outputs.TAG_NAME }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,27 @@
+name: Build Website Docker Image
+on: create
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event.ref_type == 'tag'
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/website:latest


### PR DESCRIPTION
Related to #559 

Create an action to publish images to DockerHub
Secrets were added to GitHub

A test tag was created and this is working. Available [here](https://hub.docker.com/r/openknowledge/website/tags?page=1&ordering=last_updated)

![image](https://user-images.githubusercontent.com/3237309/122990359-3d215e80-d37a-11eb-905e-5276653699fe.png)

