### PR TITLE
Cache and search engine changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,5 @@ RUN . /root/.nvm/nvm.sh && nvm use 10
 ENV PORT 80
 EXPOSE $PORT
 
-RUN python manage.py collectstatic --noinput
-
-CMD python manage.py migrate && python manage.py update_index && /usr/bin/supervisord
+COPY ./docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Collect static files"
+python manage.py collectstatic --noinput
+
+echo "Apply database migrations"
+python manage.py migrate
+
+echo "Updating search index"
+python manage.py update_index || echo "Failed to update the search index"
+
+echo "Starting serving app"
+/usr/bin/supervisord

--- a/docs/cloud/google-deploy.md
+++ b/docs/cloud/google-deploy.md
@@ -83,7 +83,7 @@ Django `static` files lives in a local folder (it would be better to move them
 ### Redis
 
 Google bring us Redis through the _Memorystore_ service
-([staging](https://console.cloud.google.com/memorystore/redis/instances?project=melodic-keyword-303819) - 
+(staging: deleted) - 
  [prod](https://console.cloud.google.com/memorystore/redis/instances?project=oki-website-production)),
 this [requires](https://medium.com/google-cloud/using-memorystore-with-cloud-run-82e3d61df016)
 a VPC connector
@@ -101,8 +101,7 @@ CACHE_URL=redis://10.23.81.3:6379/0
 ### Elasticsearch
 
 Google allow using Elastic through a special service
-manged by Elastic(
-[staging](https://cloud.elastic.co/deployments/d1bdd16cf365403fa92fdd7320a4d527) - 
+manged by Elastic (staging: deleted - 
 [prod](https://cloud.elastic.co/deployments/cecdc3ed33384418842d9cadfb2ff24c))
 (external provider).  
 Note that `python manage.py update_index` runs every time we build the DockerFile.  

--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -249,11 +249,11 @@ elif CACHE_URL.upper() == 'DB':
 elif CACHE_URL.upper() == 'FILE':
     # File system cache
     CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': '/var/tmp/django_fs_cache',
+        'default': {
+            'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+            'LOCATION': '/var/tmp/django_fs_cache',
+        }
     }
-}
 
 # Database configuration
 


### PR DESCRIPTION
Related to #602 

This PR:
 - Prepare cache and search to work without external and expensive services
 - Make some changes in the Dockerfile to make it easier

Redis and Elasticsearch were removed for staging environment and everything continues working (next.okfn.org)
In staging, we are now using a file cache instead Redis and Whoosh backed (local file) as search engine. It's not the best/scalable approach but seems enough for our use case

If this PR is good we must:
 - Remove Redis and Elasticsearch for production and move to file based services as staging
