### PR TITLE
Privacy policy changes

### DIFF
--- a/docs/private-policy/private-policy.html
+++ b/docs/private-policy/private-policy.html
@@ -32,12 +32,6 @@
                 application, and does not store any personally identifiable information.</li>
         </ul>
     </li>
-    <li>
-        <strong>_plausible_key</strong> From 
-        <a alt="Link - Plausible" href="https://plausible.io/">Plausible</a> 
-        (check the Plausible <a heref="https://plausible.io/data-policy">Data Policty</a>)<br /></a>
-        We use it to record the number of site visits, the navigation paths, and number of visitors to each page.
-    </li>
 </ul>
 
 <h4>Cookies which <strong>may </strong>contain personal identification</h4>

--- a/docs/private-policy/private-policy.html
+++ b/docs/private-policy/private-policy.html
@@ -32,38 +32,18 @@
                 application, and does not store any personally identifiable information.</li>
         </ul>
     </li>
+    <li>
+        <strong>_plausible_key</strong> From 
+        <a alt="Link - Plausible" href="https://plausible.io/">Plausible</a> 
+        (check the Plausible <a heref="https://plausible.io/data-policy">Data Policty</a>)<br /></a>
+        We use it to record the number of site visits, the navigation paths, and number of visitors to each page.
+    </li>
 </ul>
 
-<h4>Cookies which <strong>may </strong>contain personal identification - we ask you to either accept or decline</h4>
+<h4>Cookies which <strong>may </strong>contain personal identification</h4>
 
-<p>Other cookies may contain trace bits of personal information, such as your preferred language, to give you a better
-    user experience, or record the number of site visits, the navigation paths, and number of visitors to each page. We
-    use Google Analytics for this purpose. They help us to understand your interests, and provide us with statistical
-    data which we can use in our funder reports. If you log into any of our sites, either with a private login, or by
+<p>If you log into any of our sites, either with a private login, or by
     using a Social Media login, then cookies will be installed.</p>
-
-<p><strong>We have installed the GDPR compliant solutions provided by Google Analytics</strong>, so that you data is
-    anonymised, and we can no longer identify the geolocation of your IP number.</p>
-
-<ul>
-    <li><strong>_collect </strong><br />
-        Amazon&rsquo;s Google Analytics _collect cookie is used to send data to Google Analytics about the visitor&#39;s
-        device and behaviour. It tracks the visitor across devices and marketing channels, though we do not use the
-        marketing, nor have any advertising on our sites. This cookie helps us understand who has&nbsp;visited our sites
-        and which pages they have visited. This information is used to enhance our websites as well as report in
-        aggregated form to our funders.</li>
-    <li><strong>_ga </strong><br />
-        Amazon&rsquo;s Google Analytics _ga cookie identifies unique users, unique sessions, and can throttle the
-        request rate if needed. In order for Google Analytics to determine that two distinct hits belong to the same
-        user, a unique identifier, associated with that particular user, must be sent with each hit. This information is
-        then harvested by Google Analytics to provide us with statistical data of site usage.</li>
-    <li><strong>_gat </strong><br />
-        Amazon&rsquo;s Google Analytics _gat cookie does not store any user information, it is just used to limit the
-        number of requests made to doubleclick.net.</li>
-    <li><strong>_gid </strong><br />
-        Amazon&rsquo;s Google Analytics cookie speeds up the delivery of web content, by using Amazon&rsquo;s worldwide
-        network of datacenters.</li>
-</ul>
 
 <p>We ask, on your first visit following our implementation of the new GDPR regulations, that you either consent to
     having cookies that may contain personally identifying information installed, or else decline the installation of

--- a/docs/private-policy/private-policy.html
+++ b/docs/private-policy/private-policy.html
@@ -4,16 +4,19 @@
     may be revised, from time to time. You may wish to revisit it regularly. This policy becomes active on the 25th May
     2018, in line with the new General Data Protection Regulation (GDPR) of 25th May 2018.</p>
 
+
+<h3>User tracking</h3>
+
+We collect anonymised tracking data to gather statistical data to help us report on growth of our organisation&rsquo;s followers to our funders. We are currently using <a href="https://plausible.io">Plausible</a> for this, which doesn't collect any Personal Identifiable Information (PII). For more information you can check Plausible's <a href="https://plausible.io/privacy">privacy policy</a>.
+
+In the past we have used Google Analytics to track visits to our sites. If you find a site still using Google Analytics please let us know at <strong>admin [at] okfn.org</strong>. In that case you will be prompted to either accept or reject cookies that might contain PII.
+
+
 <h3>Cookies</h3>
 
 <p>Cookies are small text files that are placed on your machine to help the site provide a better user experience. In
     general, cookies are used to retain user preferences, store information for things like shopping carts, and provide
-    anonymised tracking data to third party applications like Google Analytics which we use to gather statistical data
-    to help us report on growth of our organisation&rsquo;s followers to our funders.</p>
-
-<p>We use two different types of cookies of our site:</p>
-
-<p>Cookies which contain no personal identification - mandatory</p>
+    </p>
 
 <p>Some cookies are needed to allow our websites to function correctly, improve performance and provide security to our
     sites. Without the installation of these cookies, our sites may either not run at all, or give very poor
@@ -33,24 +36,6 @@
         </ul>
     </li>
 </ul>
-
-<h4>Cookies which <strong>may </strong>contain personal identification</h4>
-
-<p>If you log into any of our sites, either with a private login, or by
-    using a Social Media login, then cookies will be installed.</p>
-
-<p>We ask, on your first visit following our implementation of the new GDPR regulations, that you either consent to
-    having cookies that may contain personally identifying information installed, or else decline the installation of
-    these cookies. Of course, in order for us to know either way what your preferences are, we need to set a cookie!
-    This is a conundrum - but we believe it is the only way to comply with the new GDPR regulations. This cookie is only
-    stored on your computer. We do not keep any record of your decision. If you delete the cookie data, or if you arrive
-    at our site from another computer or browser, you will be asked again to accept or decline our cookies.</p>
-
-<h4>If you do not make a choice</h4>
-
-<p>If you choose to neither Accept or Decline cookies when our cookie banner displays, and continue to browse the site,
-    our default behaviour will be to install cookies, as we have given you an opportunity to act before cookies are set
-    on a first visit to a site. This is considered by us to be &ldquo;Soft Opt-in&rdquo; consent.</p>
 
 <h4>How to manually change your cookie preferences</h4>
 
@@ -92,8 +77,7 @@
     account or attempt to use a remail service.</p>
 
 <p>Page edits, comments, trackbacks, and pingbacks and other activity on our websites may be identified by your IP
-    address, though we have now implemented Google Analytics GDPR solutions, which strips out the last two numbers from
-    the IP address in order to become anonymous.</p>
+    address.</p>
 
 <p>If you are concerned about attempts to match your IP address to your identity, you may wish to use an anonymous
     browsing service or attempt some means to obfuscate your real IP address. If so, you might like to try Tor, an
@@ -113,17 +97,13 @@
     of unsolicited mail. We will do our best to ensure that anything we do send to you will be relevant and unobtrusive.
 </p>
 
-<h3>Server Logging &amp; Google Analytics</h3>
+<h3>Server Logging</h3>
 
 <p>Any time you visit a page on the internet, you send quite a bit of information to the server. The web servers that
     host this site maintain access logs with the information that you send. This information is used to provide site
     statistics and to get an idea of popular pages and what sites link here. We do not intend to use these logs to
     identify legitimate users. The data logged may be used by us to solve technical problems with the site and, in cases
-    of abuse of this site, to investigate the abuse. We use Google Analytics to gather data from cookies to analyse our
-    website traffic in order to provide better services and to set benchmarks for how we are doing in meeting Open
-    Knowledge Foundation&#39;s goals. We have now implemented Google Analytics&rsquo; GDPR recommendations in order to
-    ensure that we meet GDPR compliance. The main change is that we can no longer see the full IP number of a visitor,
-    and so we cannot tell which country the visitor is likely to come from.</p>
+    of abuse of this site, to investigate the abuse.</p>
 
 <h3>Data release policy</h3>
 


### PR DESCRIPTION
We are moving from Google Analytics to Plausible in all our sites and we need to update our private policy

This PR is to define our new privacy policy
We are now using Plausible and [this](https://plausible.io/data-policy) is their data policy.
They say _By using Plausible, you don’t need to have any GDPR, CCPA or PECR prompts_

More [here](https://plausible.io/blog/privacy-policy-page)
