### PR TITLE
Test hide hibernated groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2022-11-25 - Fix PayPal donate button
+ - Manually hide hibernated network groups [#744](https://github.com/okfn/website/pull/744)
+
 ## 2022-08-09 - Fix PayPal donate button
 
  - Allow PayPal image and for to fix the _Donate_ button [#721](https://github.com/okfn/website/pull/721)

--- a/foundation/organisation/templates/organisation/networkgroup_flags.html
+++ b/foundation/organisation/templates/organisation/networkgroup_flags.html
@@ -1,3 +1,9 @@
+{% comment %}
+    Hack to hide network groups
+    To allow show/hide groups a new `visible` field will be required
+{% endcomment %}
+
+{% if title != 'Hibernated group' %}
 <div class="col-md-4 col-xs-12">
     <h3>{{ title }}{{ countries|length|pluralize }}</h3>
     <ul class="network-countries">{% for networkgroup in countries %}
@@ -9,3 +15,4 @@
         </li>
     {% endfor %}</ul>
 </div>
+{% endif %}


### PR DESCRIPTION
Comms team requires to hide the _Hibernated groups_

This is a simple hack. 
If this need to be a feature to hide/show groups (I don't think so) a good aprproach could be to:
 - Add a `visible` field to the `NetworkGroupList` model.
 - Add `NetworkGroupList` to the admin to allow users to modify this field
 - Update the `NetworkGroupFlagsPlugin` to hide non visible groups