### PR TITLE
Add missing space to list class Fix #886

### DIFF
--- a/foundation/okfplugins/list/templates/list_plugin.html
+++ b/foundation/okfplugins/list/templates/list_plugin.html
@@ -1,5 +1,5 @@
 {% load markdown_deux_tags %}
-<div class="list{% if instance.list_type != 'long' %}-{{instance.list_type}}{% endif %} mb-20">
+<div class="list{% if instance.list_type != 'long' %} -{{instance.list_type}}{% else %}{% endif %} mb-20">
   <h1 class="title">{{ instance.title }}</h1>
     <div class="content block-txt">
         <ul>

--- a/foundation/okfplugins/list/templates/list_plugin.html
+++ b/foundation/okfplugins/list/templates/list_plugin.html
@@ -1,5 +1,5 @@
 {% load markdown_deux_tags %}
-<div class="list{% if instance.list_type != 'long' %} -{{instance.list_type}}{% else %}{% endif %} mb-20">
+<div class="list{% if instance.list_type != 'long' %} -{{instance.list_type}}{% endif %} mb-20">
   <h1 class="title">{{ instance.title }}</h1>
     <div class="content block-txt">
         <ul>


### PR DESCRIPTION
This adds a missing space for the short or xl list. Their classes must be class="list -short ..." or class="list -xl" respectively. Fix #886 