### PR TITLE
911 Re introduce messages block

### DIFF
--- a/foundation/organisation/templates/organisation/board_details.html
+++ b/foundation/organisation/templates/organisation/board_details.html
@@ -3,11 +3,6 @@
 
 {% block title %}{{ object.name }}{% endblock %}
 
-{% block pagebanner-inner %}
-<h2>{{ object.name }}</h2>
-<p>{{ object.description }}</p>
-{% endblock %}
-
 {% block custom_sidebar %}
   <h3>Members</h3>
   <ul>{% for membership in object.boardmembership_set.all %}

--- a/foundation/organisation/templates/organisation/theme_detail.html
+++ b/foundation/organisation/templates/organisation/theme_detail.html
@@ -5,11 +5,6 @@
 
 {% block title %}{{ object.name }}{% endblock %}
 
-{% block pagebanner-inner %}
-<h2>{{ object.name }}</h2>
-<p>{{ object.blurb|markdown }}</p>
-{% endblock %}
-
 {% block custom_sidebar %}
     <h3>Other themes</h3>
     <ul>

--- a/foundation/search/templates/search/search.html
+++ b/foundation/search/templates/search/search.html
@@ -4,23 +4,6 @@
 
 {% block title %}{% trans 'Search' %}{% endblock %}
 
-{% block pagebanner %}
-  <div class="banner">
-    <div class="container">
-      <div class="banner_text">
-        <h2>{% trans 'Search' %}</h2>
-        {% if query %}
-          <p>
-          {% blocktrans with num=page.object_list|length %}
-            Your search for: "{{ query }}" returned {{ num }} results.
-          {% endblocktrans %}
-          </p>
-        {% endif %}
-      </div>
-    </div>
-  </div>
-{% endblock %}
-
 {% block main %}
     <form action="." method="get" class="form">
       <div class="input-fake flex items-center">

--- a/sendemail/views.py
+++ b/sendemail/views.py
@@ -13,7 +13,9 @@ def contactview(request):
 
     form = ContactForm(request.POST)
     if not form.is_valid():
-        messages.error(request, 'Required information is missing')
+        fields = [field for field in form.errors.keys()]
+        msg = f'Required information is missing: {", ".join(fields)}'
+        messages.error(request, msg)
         return render(request, "cms_contact.html", {'form': form})
 
     name = form.cleaned_data['name']

--- a/templates/403.html
+++ b/templates/403.html
@@ -3,14 +3,6 @@
 
 {% block title %}{% trans 'Permission denied' %}{% endblock %}
 
-{% block messages %}
-<div id='page-banner'>
-  <div class='container'>
-    <h2>403: {% trans 'Permission denied' %}</h2>
-  </div>
-</div>
-{% endblock %}
-
 {% block body %}
 <div class='row'>
   <div class='col-md-8'>

--- a/templates/403.html
+++ b/templates/403.html
@@ -3,7 +3,7 @@
 
 {% block title %}{% trans 'Permission denied' %}{% endblock %}
 
-{% block pagebanner %}
+{% block messages %}
 <div id='page-banner'>
   <div class='container'>
     <h2>403: {% trans 'Permission denied' %}</h2>

--- a/templates/404.html
+++ b/templates/404.html
@@ -7,8 +7,6 @@
 {% endblock %}
 
 {% block body-class %}page-template{% endblock %}
-{% block messages %}
-{% endblock %}
 
 {% block body %}
 <div class="headline -tighten-1 text-center mb-20">

--- a/templates/404.html
+++ b/templates/404.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block body-class %}page-template{% endblock %}
-{% block pagebanner %}
+{% block messages %}
 {% endblock %}
 
 {% block body %}

--- a/templates/cms_default.html
+++ b/templates/cms_default.html
@@ -7,9 +7,6 @@
 {% endblock %}
 
 {% block body-class %}page-template{% endblock %}
-{% block pagebanner %}
-{% include 'includes/banner.html' %}
-{% endblock %}
 
 {% block body %}
       {% placeholder "page content" %}

--- a/templates/cms_homepage.html
+++ b/templates/cms_homepage.html
@@ -4,29 +4,6 @@
 {% load static %}
 {% block head-scripts %}<script src="https://www.youtube.com/player_api"></script>{% endblock head-scripts %}
 {% block body-class %}home-template{% endblock %}
-{% block pagebanner %}
-  <section class="banner">
-  <div class="container">
-    <div class="banner_text">
-      {% placeholder "blurb" %}
-    </div>
-    <div class="banner_video">
-      <div class="banner_video-inner">
-        <span class="plugin_picture">
-          {% placeholder "banner thumb" %}
-        </span>
-        {% placeholder "banner video" %}
-        <button class="banner_video-play btn" aria-label="Play video" id="play-home-video">
-          <span class="icon-arrow-right" aria-hidden="true"></span>
-        </button>
-        <button class="banner_video-close btn" aria-label="Close video" id="close-home-video">
-          <span class="icon-close" aria-hidden="true"></span>
-        </button>
-      </div>
-    </div>
-  </div>
-</section>
-{% endblock %}
 
 {% block body %}
 <!-- hero -->

--- a/templates/cms_landing.html
+++ b/templates/cms_landing.html
@@ -7,9 +7,6 @@
 {% endblock %}
 
 {% block body-class %}page-template{% endblock %}
-{% block messages %}
-{% include 'includes/messages.html' %}
-{% endblock %}
 
 {% block body %}
       {% placeholder "page content" %}

--- a/templates/cms_landing.html
+++ b/templates/cms_landing.html
@@ -7,8 +7,8 @@
 {% endblock %}
 
 {% block body-class %}page-template{% endblock %}
-{% block pagebanner %}
-{% include 'includes/banner.html' %}
+{% block messages %}
+{% include 'includes/messages.html' %}
 {% endblock %}
 
 {% block body %}

--- a/templates/cms_twocolumn.html
+++ b/templates/cms_twocolumn.html
@@ -7,9 +7,6 @@
 {% endblock %}
 
 {% block body-class %}page-template{% endblock %}
-{% block pagebanner %}
-{% include 'includes/banner.html' %}
-{% endblock %}
 
 {% block body %}
 <section class="sect sect-features -tighten-1 mb-20">

--- a/templates/general.html
+++ b/templates/general.html
@@ -72,7 +72,9 @@
                 </div>
               </nav>
             </div>
-            {% block messages %}{% endblock %}
+            {% block messages %}
+              {% include 'includes/messages.html' %}
+            {% endblock %}
           </header>
           <!-- /header -->
           {% block body %}{% endblock %}

--- a/templates/general.html
+++ b/templates/general.html
@@ -25,7 +25,7 @@
               <a href="/" class="lg">
                 <img src="{% static 'images/lg-okfn.svg' %}" class="h-[4.375rem] md:h-[5.625rem]" alt="Open Knowledge Foundation">
               </a>
-          
+
               <nav class="main-nav">
                 <label for="main-nav__switcher-indicator" class="icon relative z-50 lg:hidden cursor-pointer">
                   <img src="{% static '/images/icons/menu.svg' %}" class="icon-menu" alt="Menu">
@@ -35,7 +35,7 @@
                   <a href="/" class="lg">
                     <img src="{% static '/images/lg-okfn-black.svg' %}" class="h-20" alt="Open Knowledge Foundation">
                   </a>
-          
+
                   <ul class="main-nav__menu">
                     {% show_menu_below_id "home" 0 1 1 100 "menu/menu.html" %}
                     <li class="main-nav__item -search switcher">
@@ -72,7 +72,7 @@
                 </div>
               </nav>
             </div>
-
+            {% block messages %}{% endblock %}
           </header>
           <!-- /header -->
           {% block body %}{% endblock %}

--- a/templates/general.html
+++ b/templates/general.html
@@ -72,11 +72,9 @@
                 </div>
               </nav>
             </div>
-            {% block messages %}
-              {% include 'includes/messages.html' %}
-            {% endblock %}
           </header>
           <!-- /header -->
+          {% include 'includes/messages.html' %}
           {% block body %}{% endblock %}
         </div>
       </div>

--- a/templates/includes/messages.html
+++ b/templates/includes/messages.html
@@ -3,9 +3,7 @@
 {% block messages %}
 <div class="container">
   {% if messages %}
-
       {% for message in messages %}
-
         {% if message.tags == 'success' %}
             <div class="alert alert-success" role="alert">
         {% else %}
@@ -15,28 +13,9 @@
             <div class="alert alert-primary" role="alert">
           {% endif %}
         {% endif %}
-
             {{message}}
             </div>
-
       {% endfor %}
-
   {% endif %}
 </div>
 {% endblock %}
-
-<div class="banner">
-  <div class="container">
-    <div class="banner_text">
-      {% block pagebanner-inner %}
-        <h2>{% page_attribute "page_title" %}</h2>
-        {% placeholder "blurb" %}
-      {% endblock %}
-    </div>
-    <div class="banner_image">
-      <span class="plugin_picture">
-        {% placeholder "banner image" inherit %}
-      </span>
-    </div>
-  </div>
-</div>

--- a/templates/includes/messages.html
+++ b/templates/includes/messages.html
@@ -1,21 +1,17 @@
 {% load cms_tags %}
 
 {% block messages %}
-<div class="container">
-  {% if messages %}
-      {% for message in messages %}
-        {% if message.tags == 'success' %}
-            <div class="alert alert-success" role="alert">
-        {% else %}
-          {% if message.tags == 'warning' or message.tags == 'error' %}
-            <div class="alert alert-danger" role="alert">
-          {% else %}
-            <div class="alert alert-primary" role="alert">
-          {% endif %}
-        {% endif %}
-            {{message}}
-            </div>
-      {% endfor %}
-  {% endif %}
+{% if messages %}
+{% for message in messages %}
+<div class="banner -{{message.tags}} mb-20">
+  <div class="banner__content">
+    <div class="container">
+      <div class="col-span-full">
+        <span class="title">{{message}}</span>
+      </div>
+    </div>
+  </div>
 </div>
+{% endfor %}
+{% endif %}
 {% endblock %}

--- a/templates/sitemap.html
+++ b/templates/sitemap.html
@@ -6,19 +6,6 @@
 {% trans 'Sitemap' %}
 {% endblock %}
 
-{% block messages %}
-<div id='page-banner'>
-  <div class='container'>
-    <h2>{% trans 'Sitemap' %}</h2>
-    <p>
-    {% blocktrans %}
-    A full overview of every page on the site
-    {% endblocktrans %}
-    </p>
-  </div>
-</div>
-{% endblock %}
-
 {% block body %}
 <div class='row'>
   <div class='main col-md-12'>

--- a/templates/sitemap.html
+++ b/templates/sitemap.html
@@ -6,7 +6,7 @@
 {% trans 'Sitemap' %}
 {% endblock %}
 
-{% block pagebanner %}
+{% block messages %}
 <div id='page-banner'>
   <div class='container'>
     <h2>{% trans 'Sitemap' %}</h2>


### PR DESCRIPTION
Fixes #911 

## Notes and Background
 - As stated in #911 , the former `pagebanner` was used as the opening "section" of each page. Which now is obsolete.
 - However, when removing it, we also removed the ability to display messages to the enduser
 - We couldn't re-introduce the block as it was since it contained obsolete content.

## Solution
 - I removed the block
 - I refactored the `messages` feature and included it as a standalone snippets in `general.html`
 - The style is according to: https://ishigami.github.io/okfn_front/components.html

## Screenshots

![image](https://github.com/okfn/website/assets/6672339/b93971e5-5c3d-49f4-ac40-c0b82709d460)

![Screenshot from 2023-07-14 10-18-44](https://github.com/okfn/website/assets/6672339/48553da2-7485-4f16-9a5a-dd685baec5c7)
