### PR TITLE
875 Contact form tweaks

### DIFF
--- a/sendemail/forms.py
+++ b/sendemail/forms.py
@@ -23,7 +23,7 @@ class ContactForm(forms.Form):
     name = forms.CharField(label='Name')
     name.widget.attrs = {'class': "form-control input-lg"}
 
-    organisation = forms.CharField(required=False, label='Organization')
+    organisation = forms.CharField(required=False, label='Organisation')
     organisation.widget.attrs = {'class': "form-control input-lg"}
 
     website = forms.URLField(required=False, label='Website')

--- a/templates/cms_contact.html
+++ b/templates/cms_contact.html
@@ -61,6 +61,10 @@
               {{ form.captcha }}
               {{ form.captcha.errors }}
           </div>
+          <div>
+            By submitting this form you agree to our <a class="font-mono" href="/privacy-policy/">Privacy Policy</a>.
+          </div>
+          <br>
         <button type="submit" class="btn btn-primary btn-lg">Send</button>
       </form>
     </div>

--- a/templates/cms_contact.html
+++ b/templates/cms_contact.html
@@ -23,27 +23,27 @@
         {% csrf_token %}
           <div class="input-fake flex items-center mb-5">
           <input id="type" type='hidden' name="type" value="Service"/>
-          <label class="font-bold mr-10">{{form.name.label}}:</label>
+          <label class="font-bold mr-10">{{form.name.label}}</label>
             {{ form.name }}
             {{ form.name.errors }}
           </div>
           <div class="input-fake flex items-center mb-5">
-          <label class="font-bold mr-10">{{form.organisation.label}}:</label>
+          <label class="font-bold mr-10">{{form.organisation.label}}</label>
             {{ form.organisation }}
             {{ form.organisation.errors }}
           </div>
           <div class="input-fake flex items-center mb-5">
-            <label class="font-bold mr-10">{{form.website.label}}:</label>
+            <label class="font-bold mr-10">{{form.website.label}}</label>
               {{ form.website }}
               {{ form.website.errors }}
           </div>
           <div class="input-fake flex items-center mb-5">
-          <label class="font-bold mr-10">{{form.email.label}}:</label>
+          <label class="font-bold mr-10">{{form.email.label}}</label>
             {{ form.email }}
             {{ form.email.errors }}
           </div>
           <div class="input-fake flex items-left flex-col mb-5">
-            <label class="message font-bold">{{form.how_can_we_help.label}}:</label>
+            <label class="message font-bold">{{form.how_can_we_help.label}}</label>
               {{ form.how_can_we_help }}
               {{ form.how_can_we_help.errors }}
           </div>
@@ -53,7 +53,7 @@
             {{ form.message }}
           </div>
           <div class="input-fake flex items-left flex-col mb-5">
-            <label class="message font-bold">{{form.telephone.label}}:</label>
+            <label class="message font-bold">{{form.telephone.label}}</label>
               {{ form.telephone }}
               {{ form.telephone.errors }}
           </div>

--- a/templates/cms_contact.html
+++ b/templates/cms_contact.html
@@ -23,7 +23,7 @@
         {% csrf_token %}
           <div class="input-fake flex items-center mb-5">
           <input id="type" type='hidden' name="type" value="Service"/>
-          <label class="font-bold mr-10">{{form.name.label}}</label>
+          <label class="font-bold mr-10">{{form.name.label}}*</label>
             {{ form.name }}
             {{ form.name.errors }}
           </div>
@@ -38,7 +38,7 @@
               {{ form.website.errors }}
           </div>
           <div class="input-fake flex items-center mb-5">
-          <label class="font-bold mr-10">{{form.email.label}}</label>
+          <label class="font-bold mr-10">{{form.email.label}}*</label>
             {{ form.email }}
             {{ form.email.errors }}
           </div>


### PR DESCRIPTION
Small UX improvements suggested by @lucpretti 

- [x] Remove colons from all fields (e.g. it will be only `Website`, not `Website:`)

- [x] Add an asterisk to the fields Name and Email (e.g. `Name*` and `Email*`), as a way to identify required fields

- [x] Change `Organization` to `Organisation` (as in British spelling)

- [x] Add a text line between the Captcha and the Send button with the following text: `By submitting this form you agree to our Privacy Policy` (linking "Privacy Policy" to `/privacy-policy/`)

![image](https://github.com/okfn/website/assets/6672339/991e6c35-25b6-4799-93d6-39d708cbffe1)
