### PR TITLE
Allow django-cms Administration iframe to be displayed locally

### DIFF
--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -72,6 +72,7 @@ DEBUG = env.get('DJANGO_DEBUG', 'true') == 'true'
 
 if DEBUG:
     SECRET_KEY = 'f8pqx#@_x-nv+$m7q7lt^lrmby4ixjms#x*2_sskn9)%t36(!q'
+    X_FRAME_OPTIONS = "SAMEORIGIN"
 else:
     SECRET_KEY = env.get('DJANGO_SECRET_KEY')
 


### PR DESCRIPTION
When running locally I cannot access the `django-cms` Administration due to strict DENY rule set by our middleware: `django.middleware.clickjacking.XFrameOptionsMiddleware`

```
The loading of “http://127.0.0.1:8000/admin/” in a frame is denied by “X-Frame-Options“ directive set to “DENY“.
```

More info: https://docs.djangoproject.com/en/4.2/ref/clickjacking/