### PR TITLE
Clean mailchimp popup

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -47,7 +47,5 @@
 </script>
 {% block javascript-libraries %}{% endblock %}
 {% block javascript-asynchronous %}{% endblock %}
-<!-- Mailchimp popup -->
-<script type="text/javascript" src="https://downloads.mailchimp.com/js/signup-forms/popup/unique-methods/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script><script type="text/javascript">window.dojoRequire(["mojo/signup-forms/Loader"], function(L) { L.start({"baseUrl":"mc.us9.list-manage.com","uuid":"73f922f8e68e21a10efa21f02","lid":"32d370a7fc","uniqueMethods":true}) })</script>
 </body>
 </html>


### PR DESCRIPTION
This PR removes the MailChimp popup, @lucpretti feel free to close this PR if you want to keep it.

I would like to clean this popup since:
 - It is annoying
 - It is probably being blocked by common browser extensions (AddBlock, DuckDuckGo, etc)
 - It's redundant since we already have a subscribe.


![image](https://github.com/okfn/website/assets/6672339/c8ce90a6-0153-4361-aff9-2fe2bf792527)
