### PR TITLE
896 - Uninstall no longer needed Generic Plugins

### DIFF
--- a/docker-entrypoint.d/delete-orphaned-plugins.sh
+++ b/docker-entrypoint.d/delete-orphaned-plugins.sh
@@ -3,6 +3,8 @@
 # Clean remaining AppHooks left from previous removals.
 # python3 manage.py cms uninstall apphooks <AppHook> --noinput
 
+# Clean CMSPlugin objects that are not attached to a page.
+python manage.py cms uninstall plugins FilePlugin LinkPlugin QuotePlugin NetworkGroupFlagsPlugin OEmbedVideoPlugin --noinput
 
 # This will remove data in cms_cmsplugins table from all non-longer-existing plugins
 python3 manage.py cms delete-orphaned-plugins --noinput


### PR DESCRIPTION
This PR uninstall all the Generic Plugins that are no longer needed according to the list in #896 

After this PR is merge to PRD, we can proceed to delete the code and dependencies for those plugins.