### PR TITLE
Add language chooser

### DIFF
--- a/templates/general.html
+++ b/templates/general.html
@@ -52,17 +52,7 @@
                         </div>
                       </form>
                     </li>
-                    <!-- <li class="main-nav__item -language" data-current-language="English">
-                      <label class="icon">
-                        <span></span>
-                      </label>
-                      <ul class="submenu -simple">
-                        <li><a href="">English</a></li>
-                        <li><a href="">Español</a></li>
-                        <li><a href="">Português (Brasil)</a></li>
-                        <li><a href="">Français</a></li>
-                      </ul>
-                    </li> -->
+                    {% language_chooser %}
                   </ul>
                 </li>
               </ul>

--- a/templates/menu/language_chooser.html
+++ b/templates/menu/language_chooser.html
@@ -8,11 +8,11 @@
   <ul class="submenu">
     {# We filter Portuguese until all translations are finished. #}
     {% for language in languages %}
-    {% if language.1 != "Portuguese" %}
+    {% if language.0 != "pt" %}
     <li class="lang{% if current_language == language.0 %} active{% endif %}">
       <a href="{% page_language_url language.0 %}" title="{% trans " Change to language:" %} {{ language.1 }}">{{language.1 }}</a>
     </li>
     {% endif %}
     {% endfor %}
   </ul>
-  {% endif %}
+{% endif %}

--- a/templates/menu/language_chooser.html
+++ b/templates/menu/language_chooser.html
@@ -1,0 +1,18 @@
+{% load i18n menu_tags static %}
+
+{% if languages|length > 1 %}
+<li class="main-nav__item -has-submenu has-children">
+  <label>
+    <img src="{% static '/img/icons/header-globe.svg' %}" class="max-w-none" alt="Language">
+  </label>
+  <ul class="submenu">
+    {# We filter Portuguese until all translations are finished. #}
+    {% for language in languages %}
+    {% if language.1 != "Portuguese" %}
+    <li class="lang{% if current_language == language.0 %} active{% endif %}">
+      <a href="{% page_language_url language.0 %}" title="{% trans " Change to language:" %} {{ language.1 }}">{{language.1 }}</a>
+    </li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+  {% endif %}


### PR DESCRIPTION
Implements #995 

This PR adds a menu item to choose different languages. It follows the `django-cms` practices:
 - https://docs.django-cms.org/en/latest/reference/templatetags.html?highlight=language_chooser#language-chooser
 - https://github.com/django-cms/django-cms/blob/develop/menus/templates/menu/language_chooser.html

![image](https://github.com/okfn/website/assets/6672339/49dbbffd-6aaf-4768-8c3b-4c54e1beee5c)
