### PR TITLE
Switch Portuguese for French

### DIFF
--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -296,7 +296,7 @@ LANGUAGE_CODE = 'en'
 LANGUAGES = [
     ('en', 'English'),
     ('es', 'Spanish'),
-    ('pt', 'Portuguese'),
+    ('fr', 'French'),
 ]
 
 TIME_ZONE = 'UTC'


### PR DESCRIPTION
I'm adding the French language and removing Portuguese. This will allow communications to start working on translations.

Note: We are not adding it to the language chooser until content is actually translated.