### PR TITLE
Remove Redis dependency

### DIFF
--- a/.env.base
+++ b/.env.base
@@ -26,4 +26,3 @@ DJANGO_EMAIL_HOST_PASSWORD=<change me>
 DJANGO_SECRET_KEY=<change me>
 HUBOT_API_KEY=<change me>
 # SEARCH_URL=http://localhost:9200
-# CACHE_URL=redis://localhost:6379/0

--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -226,7 +226,7 @@ WSGI_APPLICATION = 'foundation.wsgi.application'
 
 # Cache configuration
 CACHE_URL = env.get('CACHE_URL')
-if CACHE_URL.upper() == 'FILE':
+if CACHE_URL and CACHE_URL.upper() == 'FILE':
     CACHES = {
         'default': {
             'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',

--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -225,39 +225,12 @@ ROOT_URLCONF = 'foundation.urls'
 WSGI_APPLICATION = 'foundation.wsgi.application'
 
 # Cache configuration
-
-CACHE_URL = env.get('CACHE_URL')
-if not CACHE_URL:
-    CACHES = {
-        'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/var/tmp/django_fs_cache',
     }
-elif CACHE_URL.startswith('redis://'):
-    CACHES = {
-        "default": {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": CACHE_URL,
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            }
-        }
-    }
-elif CACHE_URL.upper() == 'DB':
-    # Database cache
-    # Requires python manage.py createcachetable
-    CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-            "LOCATION": env.get('CACHE_DB_TABLE_NAME', 'django_cache_table'),
-        }
-    }
-elif CACHE_URL.upper() == 'FILE':
-    # File system cache
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-            'LOCATION': '/var/tmp/django_fs_cache',
-        }
-    }
+}
 
 # Database configuration
 

--- a/foundation/settings.py
+++ b/foundation/settings.py
@@ -225,12 +225,20 @@ ROOT_URLCONF = 'foundation.urls'
 WSGI_APPLICATION = 'foundation.wsgi.application'
 
 # Cache configuration
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': '/var/tmp/django_fs_cache',
+CACHE_URL = env.get('CACHE_URL')
+if CACHE_URL.upper() == 'FILE':
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+            'LOCATION': '/var/tmp/django_fs_cache',
+        }
     }
-}
+else:
+    # Dummy cache for development
+    CACHES = {
+        'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}
+    }
+
 
 # Database configuration
 

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,6 @@ django-filer==3.1.1
 django-markdown-deux==1.0.6
 django-mptt==0.14.0
 django-pagedown==2.2.1
-django-redis==5.3.0
 django-reversion==5.0.4
 django-sekizai==4.1.0
 django-storages==1.13.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ asgiref==3.7.2
     # via
     #   django
     #   django-countries
-async-timeout==4.0.2
-    # via redis
 beautifulsoup4==4.12.2
     # via -r requirements.in
 cachetools==4.2.4
@@ -34,7 +32,6 @@ django==4.2.3
     #   django-pagedown
     #   django-polymorphic
     #   django-ranged-response
-    #   django-redis
     #   django-reversion
     #   django-sekizai
     #   django-simple-captcha
@@ -79,8 +76,6 @@ django-polymorphic==3.0.0
     # via django-filer
 django-ranged-response==0.2.0
     # via django-simple-captcha
-django-redis==5.3.0
-    # via -r requirements.in
 django-reversion==5.0.4
     # via -r requirements.in
 django-sekizai==4.1.0
@@ -179,8 +174,6 @@ pyasn1-modules==0.2.8
     # via google-auth
 pyparsing==3.0.9
     # via packaging
-redis==4.5.3
-    # via django-redis
 reportlab==3.6.5
     # via
     #   easy-thumbnails


### PR DESCRIPTION
We are no longer using Redis for cache. So I'm cleaning up this dependency and some code in the `settings.py` file.

I've double-checked our secrets in production and we are setting `CACHE_URL=FILE`.