### PR TITLE
Cleaning references to no longer existing CSS classes

### DIFF
--- a/foundation/features/templates/feature_plugin.html
+++ b/foundation/features/templates/feature_plugin.html
@@ -1,4 +1,4 @@
-<section class="sect sect-updates -tighten-1 -has-bg-circle -bg-circle-okfn-yellow before:-translate-x-1/2 before:-translate-y-1/2 mb-20">
+<section class="sect -tighten-1 -has-bg-circle -bg-circle-okfn-yellow before:-translate-x-1/2 before:-translate-y-1/2 mb-20">
   <div class="sect__content">
     <h2 class="mb-8 font-bold text-h1 leading-none">Latest <br> updates</h2>
     <div class="content-grid">
@@ -9,7 +9,7 @@
         <figure class="{{ figureClassName }}">
           <img src="/images/{{ image }}" alt="">
         </figure>
-      
+
         {% if feature.title %}
           <h3 class="title block mb-8 font-bold text-2xl">{{ feature.title }}</h3>
 

--- a/foundation/okfplugins/carousel/templates/carousel_plugin.html
+++ b/foundation/okfplugins/carousel/templates/carousel_plugin.html
@@ -1,5 +1,5 @@
 {% load cms_tags %}
-<div class="sect -tighten-2 sect-generic {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }} mb-20">
+<div class="sect -tighten-2 {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }} mb-20">
    <div class="sect__content">
      <div class="slider-wrapper -mx-12">
        <div class="slider" data-slider="{ cssEase: 'linear', slidesToShow: 1, slidesToScroll: 1 }" data-slider-mobile="{ cssEase: 'linear', slidesToShow: 1, slidesToScroll: 1 }">

--- a/foundation/okfplugins/feature_block/templates/feature_block_container_plugin.html
+++ b/foundation/okfplugins/feature_block/templates/feature_block_container_plugin.html
@@ -1,4 +1,4 @@
-<section class="sect sect-features -tighten-1 mb-20">
+<section class="sect -tighten-1 mb-20">
   <div class="sect__content">
     {% if instance.show_title %}
       <h2 class="mb-20 text-h1 text-center font-bold leading-none">{{ instance.title | safe }}</h2>

--- a/foundation/okfplugins/gallery/templates/gallery_plugin.html
+++ b/foundation/okfplugins/gallery/templates/gallery_plugin.html
@@ -1,7 +1,7 @@
 {% load cms_tags %}
 <!-- Slider-->
 {% if instance.gallery_type == 'image_slider' %}
-  <section class="sect sect-gallery true-w-full {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }} -mt-20 mb-20">
+  <section class="sect true-w-full {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }} -mt-20 mb-20">
     <div class="sect__content overflow-hidden">
       <div class="slider-wrapper">
         <div class="slider -is-width-auto" data-slider="{ autoplay: true, autoplaySpeed: 0, arrows: false, cssEase: 'linear', slidesToShow: 1, slidesToScroll: 1, speed: 9000, variableWidth: true, draggable: true, pauseOnHover: true }" data-slider-mobile="{ autoplay: true, autoplaySpeed: 0, arrows: false, cssEase: 'linear', slidesToShow: 1, slidesToScroll: 1, speed: 9000, variableWidth: true, draggable: true, pauseOnHover: true }">
@@ -14,7 +14,7 @@
   </section>
 <!-- Static Logo-->
 {% elif instance.gallery_type == 'logo_static' %}
-  <section class="sect sect-generic -tighten-1 {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }} mx-auto mb-20 text-center">
+  <section class="sect -tighten-1 {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }} mx-auto mb-20 text-center">
     <div class="sect__content">
       <h3 class="py-6 mb-20 text-2xl font-bold">{{instance.title}}</h3>
       <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 items-center gap-x-2.5 gap-y-10 mb-20">

--- a/foundation/okfplugins/grid_columns/templates/grid_columns_plugin.html
+++ b/foundation/okfplugins/grid_columns/templates/grid_columns_plugin.html
@@ -1,5 +1,5 @@
 {% load cms_tags %}
-<div class="sect -tighten-1 sect-generic mb-20">
+<div class="sect -tighten-1 mb-20">
     <div class="sect__content">
       <div class="grid {{ grid_cols_class }} gap-10 md:gap-3">
         <!--TODO: col-span-{n} did not work, so forloop is used instead-as a quick fix -->

--- a/foundation/okfplugins/header/templates/header_plugin.html
+++ b/foundation/okfplugins/header/templates/header_plugin.html
@@ -1,6 +1,6 @@
 <!-- hero -->
 {% if instance.header_type == 'h1' %}
-<section class="sect sect-hero {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }}">
+<section class="sect {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }}">
 <div class="page-opening mb-20 mt-20">
   <h1 class="title">{{ instance.title }}</h1>
   <div class="image">
@@ -12,7 +12,7 @@
 </div>
 </section>
 {% elif instance.header_type == 'h2' %}
-<section class="sect sect-hero mb-20 {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }}">
+<section class="sect mb-20 {{ has_bg_circle }} {{ instance.size }} {{ instance.color }} {{ css_translate }}">
   <div class="sect__content">
     <div class="lg:flex lg:gap-x-8 lg:items-center md:flex-row-reverse">
       <div class="flex-shrink-0">
@@ -30,7 +30,7 @@
   </div>
 </section>
 {% else %}
-<section class="sect sect-hero mb-20 {{ has_bg_circle }} {{ instance.size }} -{{ instance.color }} {{ css_translate }}">
+<section class="sect mb-20 {{ has_bg_circle }} {{ instance.size }} -{{ instance.color }} {{ css_translate }}">
   <div class="sect__content">
     <div class="lg:flex lg:gap-x-8 lg:items-center">
       <div class="flex-shrink-0">

--- a/foundation/okfplugins/hero_punch/templates/hero_punch_plugin.html
+++ b/foundation/okfplugins/hero_punch/templates/hero_punch_plugin.html
@@ -1,6 +1,6 @@
 <!-- default-->
 {% if instance.banner_type == 'default' %}
-  <section class="sect sect-splash-hero mb-20">
+  <section class="sect mb-20">
     <div class="sect__content">
       <div class="flex flex-col-reverse lg:flex-row items-center gap-10 lg:gap-2.5">
         <div class="lg:w-8/12">
@@ -17,7 +17,7 @@
 
 <!-- section default-->
 {% elif instance.banner_type == 'opening_default' %}
-  <section class="sect sect-hero -tighten-1 mx-auto -has-bg-circle -bg-circle-okfn-purple -bg-circle-lg mb-20">
+  <section class="sect -tighten-1 mx-auto -has-bg-circle -bg-circle-okfn-purple -bg-circle-lg mb-20">
     <div class="sect__content">
       <div class="lg:flex lg:gap-x-8 lg:items-center md:flex-row-reverse md:!gap-x-28">
         <div class="flex-shrink-0">
@@ -36,7 +36,7 @@
 
 <!-- section center-->
 {% elif instance.banner_type == 'opening_center' %}
-  <section class="sect sect-library md:!col-start-5 md:!col-end-9 -has-bg-circle -bg-circle-lg -bg-circle-okfn-green before:top-1/2 before:left-1/2 before:-translate-y-1/2 mb-20 text-center">
+  <section class="sect md:!col-start-5 md:!col-end-9 -has-bg-circle -bg-circle-lg -bg-circle-okfn-green before:top-1/2 before:left-1/2 before:-translate-y-1/2 mb-20 text-center">
     <div class="sect__content">
       <img src="/assets/images/home-sect-library.png"  src="{{ instance.image.url }}" alt="{{ instance.image_alt }}">
       <h2 class="mb-8 font-bold text-h1 leading-none">{{ instance.title | safe }}</h2>

--- a/foundation/okfplugins/newsletter/templates/newsletter_plugin.html
+++ b/foundation/okfplugins/newsletter/templates/newsletter_plugin.html
@@ -1,6 +1,6 @@
 <!-- sect-newsletter -->
 {% if instance.campaign_type == 'campaign' %}
-<section class="sect sect-campaign -tighten-1 mb-20">
+<section class="sect -tighten-1 mb-20">
   <div class="sect__content">
     <div class="lg:flex lg:items-center lg:gap-16">
       <img class="mx-auto mb-10 lg:mb-0 lg:flex-shrink-0 max-w-[15rem] lg:max-w-[31.625rem]" src="{% if instance.image %}{{ instance.image.url }}{% else %}/assets/img/call-to-action-newsletter.svg{% endif %}" alt="{{ instance.image_alt }}">
@@ -22,7 +22,7 @@
   </div>
 </section>
 {% elif instance.campaign_type == 'small' %}
-<section class="sect sect-call-to-action-medium mb-20">
+<section class="sect mb-20">
   <div class="sect__content">
     <div class="grid grid-cols-12 gap-y-10 lg:gap-y-0">
       <div class="col-span-full lg:col-start-2 lg:col-end-8 flex items-center lg:pr-4">
@@ -41,7 +41,7 @@
   </div>
 </section>
 {% elif instance.campaign_type == 'medium' %}
-<section class="sect sect-call-to-action-medium -tighten-3 mb-20">
+<section class="sect -tighten-3 mb-20">
   <div class="sect__content">
     <div class="flex flex-col justify-center">
       <img class="max-w-[15rem] lg:max-w-xs mx-auto mb-10 lg:mb-3"  src="{% if instance.image %}{{ instance.image.url }}{% else %}/assets/img/call-to-action-newsletter.svg{% endif %}" alt="{{ instance.image_alt }}">
@@ -58,7 +58,7 @@
   </div>
 </section>
 {% else %}
-<section class="sect sect-newsletter -tighten-1 mb-20 -has-bg-circle -bg-circle-lg before:top-full before:left-full before:-translate-y-1/2 before:-translate-x-1/2">
+<section class="sect -tighten-1 mb-20 -has-bg-circle -bg-circle-lg before:top-full before:left-full before:-translate-y-1/2 before:-translate-x-1/2">
   <div class="sect__content">
     <div class="lg:flex lg:flex-row-reverse lg:items-center lg:gap-16">
       <img class="mx-auto lg:flex-shrink-0" src="/assets/img/section-newsletter.png" alt="">

--- a/foundation/okfplugins/video/templates/video_plugin.html
+++ b/foundation/okfplugins/video/templates/video_plugin.html
@@ -1,4 +1,4 @@
-<div class="sect -tighten-2 sect-generic mb-20">
+<div class="sect -tighten-2 mb-20">
   <div class="sect__content">
     <!-- img-set-video -->
     <figure class="img-set -video -is-video" data-play-video="{{ instance.video_id }}">

--- a/foundation/organisation/templates/organisation/networkgroup_detail.html
+++ b/foundation/organisation/templates/organisation/networkgroup_detail.html
@@ -8,7 +8,7 @@
 
 {% static_placeholder "Network Group Header" %}
 <!-- hero -->
-<section class="sect sect-hero mb-20">
+<section class="sect mb-20">
   <div class="sect__content">
     <div class="lg:flex lg:gap-x-8 lg:items-center md:flex-row-reverse">
       <div class="flex-shrink-0">

--- a/templates/404.html
+++ b/templates/404.html
@@ -10,7 +10,7 @@
 <div class="headline -tighten-1 text-center mb-20">
 <h1 class="col-span-full px-3 py-5 font-bold text-center text-h1">We&#x27;re sorry, but the requested page could not be found. If you think there should have been something here, you can try searching for it:</h1>
 </div>
-<section class="sect sect-features -tighten-1 mb-20">
+<section class="sect -tighten-1 mb-20">
   <div class="sect__content">
     <form action="/search" method="get" class="form">
       <div class="input-fake flex items-center">
@@ -24,7 +24,7 @@
   </div>
 </section>
           <!-- sect-newsletter -->
-          <section class="sect sect-newsletter -tighten-1 mb-20 -has-bg-circle -bg-circle-lg before:top-full before:left-full before:-translate-y-1/2 before:-translate-x-1/2">
+          <section class="sect -tighten-1 mb-20 -has-bg-circle -bg-circle-lg before:top-full before:left-full before:-translate-y-1/2 before:-translate-x-1/2">
             <div class="sect__content">
               <div class="lg:flex lg:flex-row-reverse lg:items-center lg:gap-16">
                 <img class="mx-auto lg:flex-shrink-0" src="/assets/img/section-newsletter.png" alt="">

--- a/templates/cms/plugins/text.html
+++ b/templates/cms/plugins/text.html
@@ -1,4 +1,4 @@
-<div class="sect -tighten-2 sect-generic mb-20">
+<div class="sect -tighten-2 mb-20">
   <div class="sect__content">
     <div class="block-txt">
       {{ body|safe }}

--- a/templates/cms_apphook.html
+++ b/templates/cms_apphook.html
@@ -2,7 +2,7 @@
 {% load cms_tags %}
 
 {% block body %}
-<section class="sect sect-features -tighten-1 mb-20">
+<section class="sect -tighten-1 mb-20">
   <div class="sect__content">
     {% block main %}{% endblock %}
   </div>

--- a/templates/cms_contact.html
+++ b/templates/cms_contact.html
@@ -3,7 +3,7 @@
 
 {% block body %}
 
-<section class="sect sect-features -tighten-1 mb-20">
+<section class="sect -tighten-1 mb-20">
   <div class="sect__content">
 
     <div id="general">

--- a/templates/djangocms_picture/default/picture.html
+++ b/templates/djangocms_picture/default/picture.html
@@ -1,5 +1,5 @@
 {% load thumbnail l10n %}
-<div class="sect -tighten-2 sect-generic mb-20">
+<div class="sect -tighten-2 mb-20">
   <div class="sect__content">
 {% if picture_link %}
     <a class="highlight" href="{{ picture_link }}"

--- a/templates/includes/newsletter.html
+++ b/templates/includes/newsletter.html
@@ -6,7 +6,7 @@
 -->
 
 <!-- sect-newsletter -->
-<section class="sect sect-newsletter -tighten-1 mb-20 -has-bg-circle -bg-circle-lg before:top-full before:left-full before:-translate-y-1/2 before:-translate-x-1/2">
+<section class="sect -tighten-1 mb-20 -has-bg-circle -bg-circle-lg before:top-full before:left-full before:-translate-y-1/2 before:-translate-x-1/2">
   <div class="sect__content">
     <div class="lg:flex lg:flex-row-reverse lg:items-center lg:gap-16">
       <img class="mx-auto lg:flex-shrink-0" src="/assets/img/section-newsletter.png" alt="">

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -3,7 +3,7 @@
 {% block title %}Login{% endblock %}
 
 {% block body %}
-<section class="sect sect-features -tighten-1 mb-20">
+<section class="sect -tighten-1 mb-20">
     <div class="headline -tighten-1 text-center mb-20">
       <h1 class="col-span-full px-3 py-5 font-bold text-center text-h1">Login</h1>
     </div>


### PR DESCRIPTION
All of this `sect-*` classes are references to our all CSS structure (before Tailwind).

Currently, we only have `sect` and `sect-highlights` and `sect-spotlight`. All other no longer exist.